### PR TITLE
* Handled crashes due to API calls (Connection timeout).

### DIFF
--- a/app/src/main/java/com/guru/composecookbook/ui/cryptoappmvvm/data/repository/CryptoRepositoryImpl.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/cryptoappmvvm/data/repository/CryptoRepositoryImpl.kt
@@ -28,11 +28,11 @@ class CryptoRepositoryImpl(
             }
             emit(cryptoList ?: emptyList<Crypto>())
         } else {
-            emit(error(response.message() ?: "Failed to load data"))
+            emit(emptyList<Crypto>())
         }
 
     }.catch {
-        emit(error("Failed to load data"))
+        emit(emptyList<Crypto>())
     }.flowOn(Dispatchers.IO)
 
     override suspend fun getFavourite(): LiveData<List<Crypto>> = cryptoDao.getFavCryptos()

--- a/app/src/main/java/com/guru/composecookbook/ui/cryptoappmvvm/data/repository/CryptoRepositoryImpl.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/cryptoappmvvm/data/repository/CryptoRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.guru.composecookbook.ui.cryptoappmvvm.data.api.CryptoApi
 import com.guru.composecookbook.ui.cryptoappmvvm.data.db.daos.CryptoDao
 import com.guru.composecookbook.ui.cryptoappmvvm.data.db.entities.Crypto
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
@@ -30,6 +31,8 @@ class CryptoRepositoryImpl(
             emit(error(response.message() ?: "Failed to load data"))
         }
 
+    }.catch {
+        emit(error("Failed to load data"))
     }.flowOn(Dispatchers.IO)
 
     override suspend fun getFavourite(): LiveData<List<Crypto>> = cryptoDao.getFavCryptos()

--- a/app/src/main/java/com/guru/composecookbook/ui/moviesappmvi/data/repository/MovieRepositoryImpl.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/moviesappmvi/data/repository/MovieRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.guru.composecookbook.ui.moviesappmvi.data.models.Genre
 import com.guru.composecookbook.ui.moviesappmvi.data.models.Movie
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
@@ -25,6 +26,8 @@ class MovieRepositoryImpl(
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.IO)
 
     override suspend fun getSimilarMovies(movieId: String): Flow<List<Movie>> = flow {
@@ -35,6 +38,8 @@ class MovieRepositoryImpl(
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.IO)
 
     override suspend fun getMyWatchlist(): LiveData<List<Movie>> {
@@ -62,7 +67,8 @@ class MovieRepositoryImpl(
         } else {
             emit(emptyList<Genre>())
         }
-
+    }.catch {
+        emit(emptyList<Genre>())
     }.flowOn(Dispatchers.IO)
 
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/moviesappmvi/data/repository/MoviesLaneRepositoryImpl.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/moviesappmvi/data/repository/MoviesLaneRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.guru.composecookbook.ui.moviesappmvi.data.api.MovieApi
 import com.guru.composecookbook.ui.moviesappmvi.data.models.Movie
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
@@ -17,6 +18,8 @@ class MoviesLaneRepositoryImpl(private val movieApi: MovieApi) : MoviesLanesRepo
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.Default)
 
     override suspend fun getTrendingTVShows(): Flow<List<Movie>> = flow {
@@ -27,6 +30,8 @@ class MoviesLaneRepositoryImpl(private val movieApi: MovieApi) : MoviesLanesRepo
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.Default)
 
     override suspend fun getPopularMovies(): Flow<List<Movie>> = flow {
@@ -37,6 +42,8 @@ class MoviesLaneRepositoryImpl(private val movieApi: MovieApi) : MoviesLanesRepo
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.Default)
 
     override suspend fun getTopRatedMovies(): Flow<List<Movie>> = flow {
@@ -47,6 +54,8 @@ class MoviesLaneRepositoryImpl(private val movieApi: MovieApi) : MoviesLanesRepo
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.Default)
 
     override suspend fun getTopRatedTVShwos(): Flow<List<Movie>> = flow {
@@ -57,5 +66,7 @@ class MoviesLaneRepositoryImpl(private val movieApi: MovieApi) : MoviesLanesRepo
             emit(emptyList<Movie>())
         }
 
+    }.catch {
+        emit(emptyList<Movie>())
     }.flowOn(Dispatchers.Default)
 }


### PR DESCRIPTION
Issue: Movies demo was crashing every time due to an unhandled exception (Connection timeout).

Fix: Handled the exception using flow's DSL and thrown empty result in case any exception occurs while API calls.

Fixes #32