### PR TITLE
Delete unnecessary gradle `clean` task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,3 @@ allprojects {
         options.compilerArgs << "-Xlint:deprecation"
     }
 }
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}


### PR DESCRIPTION
There is a builtin `clean` gradle task which does the same thing?