### PR TITLE
Improvement: Remove unnecessary spacing from movies demo app main pages

### DIFF
--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/MoviesHomeActivity.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/MoviesHomeActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LibraryAdd
@@ -17,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.guru.composecookbook.moviesapp.data.db.models.Movie
@@ -48,33 +50,34 @@ class MoviesHomeActivity : ComponentActivity() {
                 Scaffold(
                     bottomBar = { MoviesBottomBar(navType) }
                 ) {
-                    Crossfade(targetState = navType) { navTypeState ->
+                    Crossfade(
+                        targetState = navType,
+                        modifier = Modifier.padding(it),
+                    ) { navTypeState ->
                         when (navTypeState.value) {
                             MovieNavType.SHOWING -> MovieHomeScreen(
-                                moviesHomeInteractionEvents = {
-                                    handleInteractionEvents(it, viewModel)
+                                moviesHomeInteractionEvents = { event ->
+                                    handleInteractionEvents(event, viewModel)
                                 }
                             )
                             MovieNavType.TRENDING -> MovieTrendingScreen(
-                                moviesHomeInteractionEvents = {
-                                    handleInteractionEvents(it, viewModel)
+                                moviesHomeInteractionEvents = { event ->
+                                    handleInteractionEvents(event, viewModel)
                                 }
                             )
                             MovieNavType.WATCHLIST -> WatchlistScreen(
-                                moviesHomeInteractionEvents = {
-                                    handleInteractionEvents(it, viewModel)
+                                moviesHomeInteractionEvents = { event ->
+                                    handleInteractionEvents(event, viewModel)
                                 }
                             )
                         }
                     }
                 }
-
-
             }
         }
     }
 
-    fun handleInteractionEvents(
+    private fun handleInteractionEvents(
         interactionEvents: MoviesHomeInteractionEvents,
         viewModel: MoviesHomeViewModel
     ) {

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/trending/components/MovieTrendingScreen.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/trending/components/MovieTrendingScreen.kt
@@ -24,7 +24,6 @@ import com.guru.composecookbook.theme.modifiers.horizontalGradientBackground
 @Composable
 fun MovieTrendingScreen(moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -> Unit) {
     val surfaceGradient = Colors.moviesSurfaceGradient(isSystemInDarkTheme())
-    val statusBarHeight = 32.dp
     val viewModel: TrendingViewModel = viewModel(
         factory = TrendingViewModelFactory(LocalContext.current)
     )
@@ -42,8 +41,6 @@ fun MovieTrendingScreen(moviesHomeInteractionEvents: (MoviesHomeInteractionEvent
             .horizontalGradientBackground(surfaceGradient)
             .verticalScroll(rememberScrollState())
     ) {
-        Spacer(modifier = Modifier.height(statusBarHeight))
-
         if (showLoading.value) {
             CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
         }
@@ -51,8 +48,6 @@ fun MovieTrendingScreen(moviesHomeInteractionEvents: (MoviesHomeInteractionEvent
         listOfSections.forEach {
             DynamicSection(it, viewModel, showLoading, moviesHomeInteractionEvents)
         }
-
-        Spacer(modifier = Modifier.height(100.dp))
     }
 }
 

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/WatchlistScreen.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/WatchlistScreen.kt
@@ -1,8 +1,6 @@
 package com.guru.composecookbook.moviesapp.ui.watch.components
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.Surface
@@ -11,7 +9,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.guru.composecookbook.moviesapp.data.db.models.Movie
 import com.guru.composecookbook.moviesapp.ui.home.MoviesHomeInteractionEvents
@@ -28,33 +25,32 @@ fun WatchlistScreen(moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -
         factory = MoviesHomeViewModelFactory(LocalContext.current)
     )
     val myWatchlist by viewModel.myWatchlist.observeAsState(emptyList())
-    if (myWatchlist.isNotEmpty()) {
-        Surface(modifier = Modifier.horizontalGradientBackground(surfaceGradient)) {
-            LazyColumn {
-                itemsIndexed(
-                    items = myWatchlist,
-                    itemContent = { index: Int, movie: Movie ->
-                        MovieWatchlistItem(
-                            movie,
-                            {
-                                moviesHomeInteractionEvents(
-                                    MoviesHomeInteractionEvents.OpenMovieDetail(movie)
-                                )
-                            },
-                            {
-                                moviesHomeInteractionEvents(
-                                    MoviesHomeInteractionEvents.RemoveFromMyWatchlist(movie)
-                                )
-                            }
-                        )
-                        if (index == myWatchlist.size - 1) {
-                            Spacer(modifier = Modifier.padding(30.dp))
-                        }
-                    })
-            }
-        }
-    } else {
+    if (myWatchlist.isEmpty()) {
         EmptyWatchlistSection()
+
+        return
+    }
+
+    Surface(modifier = Modifier.horizontalGradientBackground(surfaceGradient)) {
+        LazyColumn {
+            itemsIndexed(
+                items = myWatchlist,
+                itemContent = { _: Int, movie: Movie ->
+                    MovieWatchlistItem(
+                        movie,
+                        {
+                            moviesHomeInteractionEvents(
+                                MoviesHomeInteractionEvents.OpenMovieDetail(movie)
+                            )
+                        },
+                        {
+                            moviesHomeInteractionEvents(
+                                MoviesHomeInteractionEvents.RemoveFromMyWatchlist(movie)
+                            )
+                        }
+                    )
+                })
+        }
     }
 }
 


### PR DESCRIPTION
Removed the manually added spaces for the movie demo app pages and used the passed padding value by `Scaffold`.
Main changes is:
```kotlin
Crossfade(
    targetState = navType,
    modifier = Modifier.padding(it),
}
```