### PR TITLE
lowering api level due to timeout of api 29

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Compose UI tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 29
+          api-level: 28
           script: ./gradlew connectedCheck

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Compose UI tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 28
+          api-level: 27
           script: ./gradlew connectedCheck


### PR DESCRIPTION
api 29 is currently timeout, for more information, read [here](https://github.com/TeamNewPipe/NewPipe/pull/6678)