### PR TITLE
fix a11y of gmail like app

### DIFF
--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailHome.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailHome.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -167,7 +168,7 @@ fun GmailFloatingActionButton(navController: NavHostController, expandState: Boo
             icon = {
                 Icon(
                     imageVector = Icons.Outlined.Edit,
-                    contentDescription = null
+                    contentDescription = stringResource(id = R.string.cd_create_new_email)
                 )
             },
             text = {
@@ -266,7 +267,9 @@ fun GmailContent(
         }
 
 
-        SearchLayout(searchOffsetY.value, scaffoldState.drawerState, showUserDialog)
+        SearchLayout(searchOffsetY.value, scaffoldState.drawerState, showUserDialog){
+            navController.navigate("create")
+        }
 
     }
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/SearchLayout.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/SearchLayout.kt
@@ -1,5 +1,6 @@
 package com.guru.composecookbook.gmail.ui.home
 
+import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -12,6 +13,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Menu
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -22,7 +24,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.guru.composecookbook.gmail.R
@@ -31,7 +35,8 @@ import com.guru.composecookbook.theme.typography
 import kotlinx.coroutines.launch
 
 @Composable
-fun SearchLayout(offset: Int, drawerState: DrawerState, showUserDialog: MutableState<Boolean>) {
+fun SearchLayout(offset: Int, drawerState: DrawerState, showUserDialog: MutableState<Boolean>,
+        onCreateNewEmailClickListener : () -> Unit) {
 
     val searchLayoutHeightDp = 70.dp
     val background = if (isSystemInDarkTheme()) graySurface else Color.White.copy(alpha = 0.8f)
@@ -54,7 +59,10 @@ fun SearchLayout(offset: Int, drawerState: DrawerState, showUserDialog: MutableS
                 }
             },
         ) {
-            Icon(imageVector = Icons.Outlined.Menu, contentDescription = null)
+            Icon(
+                imageVector = Icons.Outlined.Menu,
+                contentDescription = stringResource(id = R.string.cd_gmail_menu)
+            )
         }
 
         TextField(
@@ -71,9 +79,25 @@ fun SearchLayout(offset: Int, drawerState: DrawerState, showUserDialog: MutableS
             textStyle = typography.body2
         )
 
+        val accessibilityManager =
+            LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE)
+                    as android.view.accessibility.AccessibilityManager
+        if (accessibilityManager.isEnabled && accessibilityManager.isTouchExplorationEnabled) {
+            IconButton(
+                onClick = {
+                    onCreateNewEmailClickListener.invoke()
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Edit,
+                    contentDescription = stringResource(id = R.string.cd_create_new_email)
+                )
+            }
+        }
+
         Image(
             painter = painterResource(id = R.drawable.p3),
-            contentDescription = null,
+            contentDescription = stringResource(id = R.string.cd_gmail_profile),
             modifier = Modifier
                 .padding(horizontal = 8.dp)
                 .size(32.dp)

--- a/demos/gmail/src/main/res/values/strings.xml
+++ b/demos/gmail/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="title_activity_gmail">Gmail</string>
     <string name="cd_back">Back</string>
-
+    <string name="cd_gmail_menu">Menu</string>
+    <string name="cd_gmail_profile">My profile</string>
+    <string name="cd_create_new_email">Create new email</string>
 </resources>


### PR DESCRIPTION
- Adding content description
- Adding create new email in header when talkback is active as fab button can be unreachable of really long to reach if email list behind is very long
![App screenshot showing gmail app with a button in the top bar to access Create new email feature](https://user-images.githubusercontent.com/3006608/138688745-88d8a185-80b3-4e34-ab2f-5719ac23da73.png)
