### PR TITLE
Create APK from Master Branch

### DIFF
--- a/.github/workflows/master-apk-create.yml
+++ b/.github/workflows/master-apk-create.yml
@@ -1,0 +1,59 @@
+name: Create APK from Main
+
+on:
+
+  push:
+
+    branches:
+
+    - master
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: set up JDK 11
+
+      uses: actions/setup-java@v2
+
+      with:
+
+        java-version: '11'
+
+        distribution: 'temurin'
+
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+
+      run: chmod +x gradlew
+
+      
+
+    - name: Build APK ⚙️🛠
+
+      run: bash ./gradlew assembleDebug
+
+ 
+
+    - uses: "marvinpinto/action-automatic-releases@latest"
+
+      with:
+
+          repo_token: "${{ github.token }}"
+
+          automatic_release_tag: "latest-master"
+
+          prerelease: true
+
+          title: "Staging Build"
+
+          files: app/build/outputs/apk/debug/app-debug.apk
+
+      

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <div align="center">
 
-<a href="/releases/download/latest-master/app-debug.apk" >
+<a href="https://github.com/Gurupreet/ComposeCookBook/releases/download/latest-master/app-debug.apk" >
       <img src = "https://img.shields.io/badge/Master-Master?color=7885FF&label=Sample%20App&logo=android&style=for-the-badge" />
     </a>
     <a href = "https://developer.android.com/jetpack/androidx/versions/all-channel#december_16_2020">

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 <br />
 
 <div align="center">
+
+<a href="https://github.com/yogeshpaliyal/ComposeCookBook/releases/download/latest-master/app-debug.apk" >
+      <img src = "https://img.shields.io/badge/Master-Master?color=7885FF&label=Sample%20App&logo=android&style=for-the-badge" />
+    </a>
     <a href = "https://developer.android.com/jetpack/androidx/versions/all-channel#december_16_2020">
       <img src = "https://img.shields.io/badge/Jetpack%20Compose-1.0.1-brightgreen" />
     </a>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <div align="center">
 
-<a href="https://github.com/yogeshpaliyal/ComposeCookBook/releases/download/latest-master/app-debug.apk" >
+<a href="/releases/download/latest-master/app-debug.apk" >
       <img src = "https://img.shields.io/badge/Master-Master?color=7885FF&label=Sample%20App&logo=android&style=for-the-badge" />
     </a>
     <a href = "https://developer.android.com/jetpack/androidx/versions/all-channel#december_16_2020">


### PR DESCRIPTION
Github actions will create an APK on new push in master branch.
So other users can download app directly from readme and can go through it without cloning and building app in their local system.

@Gurupreet please have a look to this. 