### PR TITLE
Add link to Jetpack Compose Components List

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Please get **Android Studio Bumblebee latest Canary** [from here](https://develo
   - [Jetpack compose Samples](https://github.com/android/compose-samples)
 
 - [Compose Academy ](https://compose.academy/)
+- [Jetpack Compose Component List](https://www.composables.com/components)
 
 ## Contribution Info
 - All the contributions are welcomed keeping following points in mind.


### PR DESCRIPTION
Include a link to [Jetpack Compose Components List](https://www.composables.com/components).

The page attracted some attention in the Android community so I figured it is worth sharing here.