### PR TITLE
feat: add infinite backward scrolling to Carousel Pager

### DIFF
--- a/components/carousel/src/main/java/com/guru/composecookbook/carousel/PagerState.kt
+++ b/components/carousel/src/main/java/com/guru/composecookbook/carousel/PagerState.kt
@@ -63,7 +63,9 @@ class PagerState(currentPage: Int = 0, minPage: Int = 0, maxPage: Int = 0) {
   suspend fun fling(velocity: Float) {
     if (velocity < 0 && currentPage == maxPage) {
       currentPage = minPage
-    } else if (velocity > 0 && currentPage == minPage) return
+    } else if (velocity > 0 && currentPage == minPage)  {
+      currentPage = maxPage
+    }
 
     _currentPageOffset.animateTo(currentPageOffset.roundToInt().toFloat())
     selectPage()

--- a/components/carousel/src/main/java/com/guru/composecookbook/carousel/PagerState.kt
+++ b/components/carousel/src/main/java/com/guru/composecookbook/carousel/PagerState.kt
@@ -63,7 +63,7 @@ class PagerState(currentPage: Int = 0, minPage: Int = 0, maxPage: Int = 0) {
   suspend fun fling(velocity: Float) {
     if (velocity < 0 && currentPage == maxPage) {
       currentPage = minPage
-    } else if (velocity > 0 && currentPage == minPage)  {
+    } else if (velocity > 0 && currentPage == minPage) {
       currentPage = maxPage
     }
 


### PR DESCRIPTION
Fixes Issue #13

This PR adds support for infinite backward scrolling in the Carousel Pager. Now users can scroll left from the first item to loop back to the last item, completing the infinite loop behavior in both directions.

Tested locally and verified smooth transitions.