### PR TITLE
Migrate Room annotation processing from KAPT to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ import com.guru.composecookbook.build.dependencies.addThirdPartyUnitTestsDepende
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -54,9 +54,6 @@ android {
       //  useIR = true
         freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
 
-    }
-    kapt {
-        correctErrorTypes = true
     }
     buildFeatures {
         compose = true

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
     // in order to be able to use "kotlin-android" in the common script
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
 
+    // in order to be able to apply "com.google.devtools.ksp" in the common scripts
+    implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:1.9.22-1.0.17")
+
     // in order to recognize the "plugins" block in the common script
     implementation("com.android.tools.build:gradle:8.2.2")
 

--- a/buildSrc/src/main/kotlin/com/guru/composecookbook/build/dependencies/DependencyHandlerExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/guru/composecookbook/build/dependencies/DependencyHandlerExtensions.kt
@@ -33,7 +33,7 @@ fun DependencyHandler.addKotlinTestDependencies() {
 }
 
 fun DependencyHandler.addDataDependencies() {
-    add("kapt", Dependencies.roomCompiler)
+    add("ksp", Dependencies.roomCompiler)
     dataDependencies.forEach {
         add("implementation", it)
     }

--- a/buildSrc/src/main/kotlin/common-kotlin-module-configs-script-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-kotlin-module-configs-script-plugin.gradle.kts
@@ -3,7 +3,7 @@ import com.guru.composecookbook.build.configurations.ProjectConfigs
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {


### PR DESCRIPTION
## Summary

Migrates Room annotation processing from KAPT to KSP, as proposed in #184.

- Replace `kotlin-kapt` with `com.google.devtools.ksp` in `app/build.gradle.kts` and the `common-kotlin-module-configs-script-plugin` convention plugin (used by `:data`, `:demos:cryptoapp:data`, `:demos:moviesapp:data`)
- `DependencyHandlerExtensions.kt`: Room compiler is now added to the `ksp` configuration instead of `kapt`
- Remove the now-unused `kapt { correctErrorTypes = true }` block from `app/build.gradle.kts`
- Add `symbol-processing-gradle-plugin:1.9.22-1.0.17` (matching Kotlin 1.9.22) to the `buildSrc` classpath so the precompiled convention scripts can apply it

KSP runs natively in the Kotlin compiler (no Java stub generation), which speeds up the affected modules' builds. This also unblocks the Kotlin 2.x upgrade (#182): Room 2.6.1's KAPT path cannot read Kotlin 2.1 metadata, while its KSP path is unaffected.

Note: the KSP plugin version intentionally lives next to the other plugin versions in `buildSrc/build.gradle.kts` rather than `Versions.kt`, because `buildSrc`'s own build script cannot reference its own sources. It must be bumped in lock-step with `Versions.kt`'s `kotlin` (the issue's remaining checklist item).

Closes #184

## Verification

- `./gradlew assembleDebug` passes locally (JDK 17, SDK 34) — all Room schemas process through KSP
- CI `./gradlew build` on this PR

## Merge order

This is PR 1 of a stacked series resolving #182–#193 (+ #13, #68). It is based directly on `master` and can merge independently; the remaining PRs in the series stack on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @Gurupreet for review
