### PR TITLE
Upgrade Kotlin to 2.1.20 and adopt the Compose Compiler Gradle plugin

### DIFF
--- a/animations/canvas/build.gradle.kts
+++ b/animations/canvas/build.gradle.kts
@@ -1,17 +1,13 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.canvas"
-}
+android { namespace = "com.guru.composecookbook.canvas" }
 
 dependencies {
-    implementation(project(":theme"))
-    addComposeOfficialDependencies()
+  implementation(project(":theme"))
+  addComposeOfficialDependencies()
 }

--- a/animations/canvas/src/main/java/com/guru/composecookbook/canvas/MultiStateAnimationCircleFilledCanvas.kt
+++ b/animations/canvas/src/main/java/com/guru/composecookbook/canvas/MultiStateAnimationCircleFilledCanvas.kt
@@ -18,24 +18,12 @@ fun MultiStateAnimationCircleFilledCanvas(color: Color = green500, radiusEnd: Fl
     transition.animateFloat(
       initialValue = 10f,
       targetValue = radiusEnd,
-      animationSpec = infiniteRepeatable(tween(1200), RepeatMode.Reverse)
+      animationSpec = infiniteRepeatable(tween(1200), RepeatMode.Reverse),
     )
   Canvas(modifier = Modifier.padding(16.dp)) {
     val centerOffset = Offset(10f, 10f)
-    drawCircle(
-      color = color.copy(alpha = 0.8f),
-      radius = floatAnim,
-      center = centerOffset,
-    )
-    drawCircle(
-      color = color.copy(alpha = 0.4f),
-      radius = floatAnim / 2,
-      center = centerOffset,
-    )
-    drawCircle(
-      color = color.copy(alpha = 0.2f),
-      radius = floatAnim / 4,
-      center = centerOffset,
-    )
+    drawCircle(color = color.copy(alpha = 0.8f), radius = floatAnim, center = centerOffset)
+    drawCircle(color = color.copy(alpha = 0.4f), radius = floatAnim / 2, center = centerOffset)
+    drawCircle(color = color.copy(alpha = 0.2f), radius = floatAnim / 4, center = centerOffset)
   }
 }

--- a/animations/canvas/src/main/java/com/guru/composecookbook/canvas/MultiStateAnimationCircleStrokeCanvas.kt
+++ b/animations/canvas/src/main/java/com/guru/composecookbook/canvas/MultiStateAnimationCircleStrokeCanvas.kt
@@ -20,7 +20,7 @@ fun MultiStateAnimationCircleStrokeCanvas() {
     transition.animateFloat(
       initialValue = 0f,
       targetValue = 360f,
-      animationSpec = infiniteRepeatable(tween(800), RepeatMode.Restart)
+      animationSpec = infiniteRepeatable(tween(800), RepeatMode.Restart),
     )
   val stroke = Stroke(8f)
   Canvas(modifier = Modifier.padding(16.dp).size(100.dp)) {

--- a/animations/lottie/build.gradle.kts
+++ b/animations/lottie/build.gradle.kts
@@ -3,18 +3,14 @@ import com.guru.composecookbook.build.dependencies.addCoreAndroidDependencies
 import com.guru.composecookbook.build.dependencies.addThirdPartyUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.lottie"
-}
+android { namespace = "com.guru.composecookbook.lottie" }
 
 dependencies {
-    addComposeOfficialDependencies()
-    addCoreAndroidDependencies()
-    addThirdPartyUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidDependencies()
+  addThirdPartyUiDependencies()
 }

--- a/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieCryptoLoadingView.kt
+++ b/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieCryptoLoadingView.kt
@@ -12,6 +12,6 @@ fun LottieCryptoLoadingView(context: Context) {
   LottieLoadingView(
     context = context,
     file = "cryptoload.json",
-    modifier = Modifier.fillMaxWidth().height(150.dp)
+    modifier = Modifier.fillMaxWidth().height(150.dp),
   )
 }

--- a/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieFoodView.kt
+++ b/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieFoodView.kt
@@ -12,6 +12,6 @@ fun LottieFoodView(context: Context) {
   LottieLoadingView(
     context = context,
     file = "food.json",
-    modifier = Modifier.fillMaxWidth().height(200.dp)
+    modifier = Modifier.fillMaxWidth().height(200.dp),
   )
 }

--- a/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieLoaderLoadingView.kt
+++ b/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieLoaderLoadingView.kt
@@ -12,6 +12,6 @@ fun LottieLoaderLoadingView(context: Context) {
   LottieLoadingView(
     context = context,
     file = "loader.json",
-    modifier = Modifier.fillMaxWidth().height(200.dp)
+    modifier = Modifier.fillMaxWidth().height(200.dp),
   )
 }

--- a/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieLoadingView.kt
+++ b/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieLoadingView.kt
@@ -15,7 +15,7 @@ fun LottieLoadingView(
   context: Context,
   file: String,
   modifier: Modifier = Modifier,
-  iterations: Int = 10
+  iterations: Int = 10,
 ) {
   val composition by rememberLottieComposition(LottieCompositionSpec.Asset(file))
   LottieAnimation(composition, modifier = modifier.defaultMinSize(300.dp), iterations = iterations)

--- a/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieWorkingLoadingView.kt
+++ b/animations/lottie/src/main/java/com/guru/composecookbook/lottie/LottieWorkingLoadingView.kt
@@ -12,6 +12,6 @@ fun LottieWorkingLoadingView(context: Context) {
   LottieLoadingView(
     context = context,
     file = "working.json",
-    modifier = Modifier.fillMaxWidth().height(250.dp)
+    modifier = Modifier.fillMaxWidth().height(250.dp),
   )
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,108 +16,95 @@ import com.guru.composecookbook.build.dependencies.addThirdPartyUiDependencies
 import com.guru.composecookbook.build.dependencies.addThirdPartyUnitTestsDependencies
 
 plugins {
-    id("com.android.application")
-    id("kotlin-android")
-    id("com.google.devtools.ksp")
-    id("org.jetbrains.kotlin.plugin.compose")
+  id("com.android.application")
+  id("kotlin-android")
+  id("com.google.devtools.ksp")
+  id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
+  compileSdk = ProjectConfigs.compileSdkVersion
+  namespace = ProjectConfigs.applicationId
 
-    compileSdk = ProjectConfigs.compileSdkVersion
-    namespace = ProjectConfigs.applicationId
+  defaultConfig {
+    applicationId = ProjectConfigs.applicationId
+    minSdk = ProjectConfigs.minSdkVersion
+    targetSdk = ProjectConfigs.targetSdkVersion
+    versionCode = 1
+    versionName = "1.0"
+    multiDexEnabled = true
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
 
-    defaultConfig {
-        applicationId = ProjectConfigs.applicationId
-        minSdk = ProjectConfigs.minSdkVersion
-        targetSdk = ProjectConfigs.targetSdkVersion
-        versionCode = 1
-        versionName = "1.0"
-        multiDexEnabled = true
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-      //  useIR = true
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
-
-    }
-    buildFeatures {
-        compose = true
-    }
-    lint {
-        abortOnError = false
-    }
-    testOptions {
-        unitTests.all {
-            it.useJUnitPlatform()
-        }
-    }
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+  kotlinOptions {
+    jvmTarget = "1.8"
+    //  useIR = true
+    freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
+  }
+  buildFeatures { compose = true }
+  lint { abortOnError = false }
+  testOptions { unitTests.all { it.useJUnitPlatform() } }
 }
 
 dependencies {
-    implementation(project(":data"))
-    implementation(project(":theme"))
-    implementation(project(":demos:instagram"))
-    implementation(project(":demos:spotify"))
-    implementation(project(":demos:twitter"))
-    implementation(project(":demos:tiktok"))
-    implementation(project(":demos:youtube"))
-    implementation(project(":demos:gmail"))
-    implementation(project(":demos:datingapp"))
-    implementation(project(":demos:paint"))
-    implementation(project(":demos:cryptoapp:app"))
-    implementation(project(":demos:moviesapp:app"))
-    implementation(project(":demos:meditation"))
-    implementation(project(":templates:onboarding"))
-    implementation(project(":templates:paymentcard"))
-    implementation(project(":templates:pinlock"))
-    implementation(project(":templates:profile"))
-    implementation(project(":templates:login"))
-    implementation(project(":templates:cascademenu"))
-    implementation(project(":components:fab"))
-    implementation(project(":components:charts"))
-    implementation(project(":components:tags"))
-    implementation(project(":components:carousel"))
-    implementation(project(":components:verticalgrid"))
-    implementation(project(":components:colorpicker"))
-    implementation(project(":components:comingsoon"))
-    implementation(project(":animations:canvas"))
-    implementation(project(":animations:lottie"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
+  implementation(project(":demos:instagram"))
+  implementation(project(":demos:spotify"))
+  implementation(project(":demos:twitter"))
+  implementation(project(":demos:tiktok"))
+  implementation(project(":demos:youtube"))
+  implementation(project(":demos:gmail"))
+  implementation(project(":demos:datingapp"))
+  implementation(project(":demos:paint"))
+  implementation(project(":demos:cryptoapp:app"))
+  implementation(project(":demos:moviesapp:app"))
+  implementation(project(":demos:meditation"))
+  implementation(project(":templates:onboarding"))
+  implementation(project(":templates:paymentcard"))
+  implementation(project(":templates:pinlock"))
+  implementation(project(":templates:profile"))
+  implementation(project(":templates:login"))
+  implementation(project(":templates:cascademenu"))
+  implementation(project(":components:fab"))
+  implementation(project(":components:charts"))
+  implementation(project(":components:tags"))
+  implementation(project(":components:carousel"))
+  implementation(project(":components:verticalgrid"))
+  implementation(project(":components:colorpicker"))
+  implementation(project(":components:comingsoon"))
+  implementation(project(":animations:canvas"))
+  implementation(project(":animations:lottie"))
 
-    addKotlinDependencies()
+  addKotlinDependencies()
 
-    addDataDependencies()
+  addDataDependencies()
 
-    addComposeOfficialDependencies()
-    addComposeDebugDependencies()
-    addComposeThirdPartyDependencies()
+  addComposeOfficialDependencies()
+  addComposeDebugDependencies()
+  addComposeThirdPartyDependencies()
 
-    addThirdPartyUiDependencies()
+  addThirdPartyUiDependencies()
 
-    addCoreAndroidDependencies()
-    addCoreAndroidUiDependencies()
-    addGoogleAndroidDependencies()
-    addNetworkingDependencies()
+  addCoreAndroidDependencies()
+  addCoreAndroidUiDependencies()
+  addGoogleAndroidDependencies()
+  addNetworkingDependencies()
 
-    addKotlinTestDependencies()
-    addJunit5TestDependencies()
-    addThirdPartyUnitTestsDependencies()
+  addKotlinTestDependencies()
+  addJunit5TestDependencies()
+  addThirdPartyUnitTestsDependencies()
 
-    addAndroidInstrumentationTestsDependencies()
-    addBiometricDependency()
+  addAndroidInstrumentationTestsDependencies()
+  addBiometricDependency()
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     id("com.android.application")
     id("kotlin-android")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -52,14 +53,11 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
       //  useIR = true
-        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
 
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = ProjectConfigs.kotlinCompilerExtensionVersion
     }
     lint {
         abortOnError = false

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ import com.guru.composecookbook.build.dependencies.addThirdPartyUnitTestsDepende
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -54,9 +54,6 @@ android {
       //  useIR = true
         freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
 
-    }
-    kapt {
-        correctErrorTypes = true
     }
     buildFeatures {
         compose = true

--- a/app/src/androidTest/java/com/guru/composecookbook/ui/home/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/guru/composecookbook/ui/home/HomeScreenTest.kt
@@ -65,7 +65,7 @@ class HomeScreenTest {
    */
   private fun hasTextInProvidedDemoData(
     homeScreenListItems: List<HomeScreenItems>,
-    ignoreCase: Boolean = false
+    ignoreCase: Boolean = false,
   ) =
     SemanticsMatcher(
       description =

--- a/app/src/androidTest/java/com/guru/composecookbook/ui/home/home_screen_options/flings/FlingSettingsPageTest.kt
+++ b/app/src/androidTest/java/com/guru/composecookbook/ui/home/home_screen_options/flings/FlingSettingsPageTest.kt
@@ -84,7 +84,7 @@ class FlingSettingsPageTest {
 
       Assert.assertEquals(
         FlingStateStore.INSTANCE.type.name.lowercase(Locale.getDefault()),
-        "native"
+        "native",
       )
     }
   }
@@ -103,7 +103,7 @@ class FlingSettingsPageTest {
 
       Assert.assertEquals(
         FlingStateStore.INSTANCE.type.name.lowercase(Locale.getDefault()),
-        "smooth"
+        "smooth",
       )
     }
   }
@@ -122,7 +122,7 @@ class FlingSettingsPageTest {
 
       Assert.assertEquals(
         FlingStateStore.INSTANCE.type.name.lowercase(Locale.getDefault()),
-        "custom"
+        "custom",
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/BottomNavType.kt
+++ b/app/src/main/java/com/guru/composecookbook/BottomNavType.kt
@@ -5,5 +5,5 @@ enum class BottomNavType {
   WIDGETS,
   ANIMATION,
   DEMOUI,
-  TEMPLATE
+  TEMPLATE,
 }

--- a/app/src/main/java/com/guru/composecookbook/MainActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/MainActivity.kt
@@ -69,7 +69,7 @@ class MainActivity : ComponentActivity() {
   @OptIn(
     ExperimentalAnimationApi::class,
     ExperimentalFoundationApi::class,
-    ExperimentalMaterialApi::class
+    ExperimentalMaterialApi::class,
   )
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -87,7 +87,7 @@ class MainActivity : ComponentActivity() {
 fun BaseView(
   appThemeState: AppThemeState,
   systemUiController: SystemUiController?,
-  content: @Composable () -> Unit
+  content: @Composable () -> Unit,
 ) {
   val color =
     when (appThemeState.pallet) {
@@ -99,11 +99,11 @@ fun BaseView(
     }
   ComposeCookBookMaterial3Theme(
     darkTheme = appThemeState.darkTheme,
-    colorPallet = appThemeState.pallet
+    colorPallet = appThemeState.pallet,
   ) {
     systemUiController?.setStatusBarColor(
       color = MaterialTheme.colorScheme.onPrimaryContainer,
-      darkIcons = appThemeState.darkTheme
+      darkIcons = appThemeState.darkTheme,
     )
     content()
   }
@@ -112,14 +112,14 @@ fun BaseView(
 @OptIn(
   ExperimentalAnimationApi::class,
   ExperimentalFoundationApi::class,
-  ExperimentalMaterialApi::class
+  ExperimentalMaterialApi::class,
 )
 @Composable
 fun HomeScreenContent(
   homeScreen: BottomNavType,
   appThemeState: MutableState<AppThemeState>,
   chooseColorBottomModalState: ModalBottomSheetState, // use for a11y
-  modifier: Modifier
+  modifier: Modifier,
 ) {
   Column(modifier = modifier) {
     Crossfade(homeScreen) { screen ->
@@ -139,7 +139,7 @@ fun HomeScreenContent(
 @OptIn(
   ExperimentalAnimationApi::class,
   ExperimentalFoundationApi::class,
-  ExperimentalMaterialApi::class
+  ExperimentalMaterialApi::class,
 )
 @Composable
 fun MainAppContent(appThemeState: MutableState<AppThemeState>) {
@@ -158,7 +158,7 @@ fun MainAppContent(appThemeState: MutableState<AppThemeState>) {
         appThemeState.value = appThemeState.value.copy(pallet = newPalletSelected)
         coroutineScope.launch { chooseColorBottomModalState.hide() }
       }
-    }
+    },
   ) {
     val config = LocalConfiguration.current
     val orientation = config.orientation
@@ -168,13 +168,13 @@ fun MainAppContent(appThemeState: MutableState<AppThemeState>) {
           homeScreen = homeScreenState.value,
           appThemeState = appThemeState,
           chooseColorBottomModalState = chooseColorBottomModalState,
-          modifier = Modifier.weight(1f)
+          modifier = Modifier.weight(1f),
         )
         BottomNavigationContent(
           modifier =
             Modifier.semantics { contentDescription = bottomNavBarContentDescription }
               .testTag(TestTags.BOTTOM_NAV_TEST_TAG),
-          homeScreenState = homeScreenState
+          homeScreenState = homeScreenState,
         )
       }
     } else {
@@ -183,13 +183,13 @@ fun MainAppContent(appThemeState: MutableState<AppThemeState>) {
           modifier =
             Modifier.semantics { contentDescription = bottomNavBarContentDescription }
               .testTag(TestTags.BOTTOM_NAV_TEST_TAG),
-          homeScreenState = homeScreenState
+          homeScreenState = homeScreenState,
         )
         HomeScreenContent(
           homeScreen = homeScreenState.value,
           appThemeState = appThemeState,
           chooseColorBottomModalState = chooseColorBottomModalState,
-          modifier = Modifier.weight(1f)
+          modifier = Modifier.weight(1f),
         )
       }
     }
@@ -199,17 +199,15 @@ fun MainAppContent(appThemeState: MutableState<AppThemeState>) {
 @Composable
 fun BottomNavigationContent(
   modifier: Modifier = Modifier,
-  homeScreenState: MutableState<BottomNavType>
+  homeScreenState: MutableState<BottomNavType>,
 ) {
   var animate by remember { mutableStateOf(false) }
-  NavigationBar(
-    modifier = modifier,
-  ) {
+  NavigationBar(modifier = modifier) {
     NavigationBarItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.Home,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.HOME,
@@ -220,16 +218,16 @@ fun BottomNavigationContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_home),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_HOME_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_HOME_TEST_TAG),
     )
     NavigationBarItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.Tools,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.WIDGETS,
@@ -240,10 +238,10 @@ fun BottomNavigationContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_widgets),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_WIDGETS_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_WIDGETS_TEST_TAG),
     )
     NavigationBarItem(
       icon = {
@@ -257,16 +255,16 @@ fun BottomNavigationContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_animation),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_ANIM_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_ANIM_TEST_TAG),
     )
     NavigationBarItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.LaptopCode,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.DEMOUI,
@@ -277,16 +275,16 @@ fun BottomNavigationContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_demoui),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_DEMO_UI_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_DEMO_UI_TEST_TAG),
     )
     NavigationBarItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.LayerGroup,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.TEMPLATE,
@@ -297,10 +295,10 @@ fun BottomNavigationContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_profile),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_TEMPLATE_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_TEMPLATE_TEST_TAG),
     )
   }
 }
@@ -311,14 +309,12 @@ private fun NavigationRailContent(
   homeScreenState: MutableState<BottomNavType>,
 ) {
   var animate by remember { mutableStateOf(false) }
-  NavigationRail(
-    modifier = modifier,
-  ) {
+  NavigationRail(modifier = modifier) {
     NavigationRailItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.Home,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.HOME,
@@ -329,16 +325,16 @@ private fun NavigationRailContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_home),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_HOME_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_HOME_TEST_TAG),
     )
     NavigationRailItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.Tools,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.WIDGETS,
@@ -349,10 +345,10 @@ private fun NavigationRailContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_widgets),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_WIDGETS_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_WIDGETS_TEST_TAG),
     )
     NavigationRailItem(
       icon = {
@@ -366,16 +362,16 @@ private fun NavigationRailContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_animation),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_ANIM_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_ANIM_TEST_TAG),
     )
     NavigationRailItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.LaptopCode,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.DEMOUI,
@@ -386,16 +382,16 @@ private fun NavigationRailContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_demoui),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_DEMO_UI_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_DEMO_UI_TEST_TAG),
     )
     NavigationRailItem(
       icon = {
         FaIcon(
           faIcon = FaIcons.LayerGroup,
-          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+          tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
         )
       },
       selected = homeScreenState.value == BottomNavType.TEMPLATE,
@@ -406,10 +402,10 @@ private fun NavigationRailContent(
       label = {
         Text(
           text = stringResource(id = R.string.navigation_item_profile),
-          style = TextStyle(fontSize = 12.sp)
+          style = TextStyle(fontSize = 12.sp),
         )
       },
-      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_TEMPLATE_TEST_TAG)
+      modifier = Modifier.testTag(TestTags.BOTTOM_NAV_TEMPLATE_TEST_TAG),
     )
   }
 }
@@ -417,7 +413,7 @@ private fun NavigationRailContent(
 @OptIn(
   ExperimentalAnimationApi::class,
   ExperimentalFoundationApi::class,
-  ExperimentalMaterialApi::class
+  ExperimentalMaterialApi::class,
 )
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/guru/composecookbook/theme/AppThemeState.kt
+++ b/app/src/main/java/com/guru/composecookbook/theme/AppThemeState.kt
@@ -2,5 +2,5 @@ package com.guru.composecookbook.theme
 
 data class AppThemeState(
   var darkTheme: Boolean = false,
-  var pallet: ColorPallet = ColorPallet.GREEN
+  var pallet: ColorPallet = ColorPallet.GREEN,
 )

--- a/app/src/main/java/com/guru/composecookbook/theme/SystemUI.kt
+++ b/app/src/main/java/com/guru/composecookbook/theme/SystemUI.kt
@@ -46,7 +46,7 @@ class SystemUiController(private val window: Window) {
   fun setStatusBarColor(
     color: Color,
     darkIcons: Boolean = color.luminance() > 0.5f,
-    transformColorForLightContent: (Color) -> Color = BlackScrimmed
+    transformColorForLightContent: (Color) -> Color = BlackScrimmed,
   ) {
     val statusBarColor =
       when {
@@ -81,7 +81,7 @@ class SystemUiController(private val window: Window) {
   fun setNavigationBarColor(
     color: Color,
     darkIcons: Boolean = color.luminance() > 0.5f,
-    transformColorForLightContent: (Color) -> Color = BlackScrimmed
+    transformColorForLightContent: (Color) -> Color = BlackScrimmed,
   ) {
     val navBarColor =
       when {
@@ -111,7 +111,7 @@ class SystemUiController(private val window: Window) {
   fun setSystemBarsColor(
     color: Color,
     darkIcons: Boolean = color.luminance() > 0.5f,
-    transformColorForLightContent: (Color) -> Color = BlackScrimmed
+    transformColorForLightContent: (Color) -> Color = BlackScrimmed,
   ) {
     setStatusBarColor(color, darkIcons, transformColorForLightContent)
     setNavigationBarColor(color, darkIcons, transformColorForLightContent)

--- a/app/src/main/java/com/guru/composecookbook/ui/animation/AnimatableSuspendingAnimations.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/animation/AnimatableSuspendingAnimations.kt
@@ -72,7 +72,7 @@ fun PointerInputWithAnimateable() {
           awaitPointerEventScope {
             horizontalDrag(
               firstDownId,
-              onDrag = { launch { pointerAnimatableX.animateTo(it.position.x) } }
+              onDrag = { launch { pointerAnimatableX.animateTo(it.position.x) } },
             )
           }
         }
@@ -80,7 +80,7 @@ fun PointerInputWithAnimateable() {
     }
   Material3Card(
     backgroundColor = green200,
-    modifier = modifier.size(100.dp).offset(x = pointerAnimatableX.value.dp)
+    modifier = modifier.size(100.dp).offset(x = pointerAnimatableX.value.dp),
   ) {}
 }
 
@@ -115,7 +115,7 @@ fun DraggableCardWithAnimatable() {
   Material3Card(
     backgroundColor = green200,
     modifier =
-      modifier.size(100.dp).offset(x = pointerAnimatableX.value.dp, y = pointerAnimatableX.value.dp)
+      modifier.size(100.dp).offset(x = pointerAnimatableX.value.dp, y = pointerAnimatableX.value.dp),
   ) {}
   Spacer(modifier = Modifier.height(100.dp))
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/animation/AnimateAsStateAnimations.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/animation/AnimateAsStateAnimations.kt
@@ -75,7 +75,7 @@ fun SimpleColorStateAnimation() {
   Button(
     onClick = { enabled.value = !enabled.value },
     colors = buttonColors,
-    modifier = Modifier.padding(16.dp).fillMaxWidth()
+    modifier = Modifier.padding(16.dp).fillMaxWidth(),
   ) {
     Text("Color Animation")
   }
@@ -112,7 +112,7 @@ fun SimpleFloatStateAnimation() {
   val animatedFloatState = animateFloatAsState(targetValue = if (enabled) 1f else 0.5f)
   Button(
     onClick = { enabled = !enabled },
-    modifier = Modifier.padding(16.dp).alpha(animatedFloatState.value)
+    modifier = Modifier.padding(16.dp).alpha(animatedFloatState.value),
   ) {
     Text("Opacity change")
   }
@@ -133,7 +133,7 @@ fun SimpleOffsetStateAnimation() {
         Modifier.size(100.dp)
           .padding(16.dp)
           .offset(x = Dp(animatedOffset.x), y = Dp(animatedOffset.y))
-          .clickable { enabled = !enabled }
+          .clickable { enabled = !enabled },
     )
     Image(
       painterResource(id = R.drawable.p2),
@@ -142,7 +142,7 @@ fun SimpleOffsetStateAnimation() {
         Modifier.size(100.dp)
           .padding(16.dp)
           .offset(x = -Dp(animatedOffset.x), y = -Dp(animatedOffset.y))
-          .clickable { enabled = !enabled }
+          .clickable { enabled = !enabled },
     )
   }
   Spacer(modifier = Modifier.height(20.dp))
@@ -166,14 +166,14 @@ fun SimpleAnimateCustomStateClass() {
       typeConverter =
         TwoWayConverter(
           convertToVector = { AnimationVector2D(it.width.value, it.rotation) },
-          convertFromVector = { CustomAnimationState(it.v1.dp, it.v2) }
+          convertFromVector = { CustomAnimationState(it.v1.dp, it.v2) },
         ),
-      animationSpec = tween(600)
+      animationSpec = tween(600),
     )
 
   Button(
     onClick = { enabled = !enabled },
-    modifier = Modifier.padding(16.dp).width(animatedUiState.width).rotate(animatedUiState.rotation)
+    modifier = Modifier.padding(16.dp).width(animatedUiState.width).rotate(animatedUiState.rotation),
   ) {
     Text("Custom State Animation")
   }
@@ -200,7 +200,7 @@ fun DrawLayerWithAnimateAsStateAnimations() {
             translationX = animateFloatAsState(if (draw2) 320f else 0f).value,
             translationY = 0f,
           )
-          .clickable(onClick = { draw2 = !draw2 })
+          .clickable(onClick = { draw2 = !draw2 }),
     )
     Image(
       painter = painterResource(id = R.drawable.dualipa),
@@ -210,9 +210,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
           .graphicsLayer(
             shadowElevation = animateFloatAsState(if (draw2) 30f else 10f).value,
             translationX = animateFloatAsState(if (draw2) -320f else 0f).value,
-            translationY = animateFloatAsState(if (draw2) 0f else 30f).value
+            translationY = animateFloatAsState(if (draw2) 0f else 30f).value,
           )
-          .clickable(onClick = { draw2 = !draw2 })
+          .clickable(onClick = { draw2 = !draw2 }),
     )
     Image(
       painter = painterResource(id = R.drawable.edsheeran),
@@ -221,9 +221,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
         Modifier.size(150.dp)
           .graphicsLayer(
             shadowElevation = animateFloatAsState(if (draw2) 30f else 5f).value,
-            translationY = animateFloatAsState(if (draw2) 0f else 50f).value
+            translationY = animateFloatAsState(if (draw2) 0f else 50f).value,
           )
-          .clickable(onClick = { draw2 = !draw2 })
+          .clickable(onClick = { draw2 = !draw2 }),
     )
   }
   Spacer(modifier = Modifier.padding(30.dp))
@@ -239,9 +239,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
             shadowElevation = animateFloatAsState(if (draw3) 30f else 5f).value,
             translationX = animateFloatAsState(if (draw3) 320f else 0f).value,
             rotationY = animateFloatAsState(if (draw3) 45f else 0f).value,
-            translationY = 0f
+            translationY = 0f,
           )
-          .clickable(onClick = { draw3 = !draw3 })
+          .clickable(onClick = { draw3 = !draw3 }),
     )
     Image(
       painter = painterResource(id = R.drawable.sam),
@@ -252,9 +252,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
             shadowElevation = animateFloatAsState(if (draw3) 30f else 10f).value,
             translationX = animateFloatAsState(if (draw3) -320f else 0f).value,
             rotationY = animateFloatAsState(if (draw3) 45f else 0f).value,
-            translationY = animateFloatAsState(if (draw3) 0f else 30f).value
+            translationY = animateFloatAsState(if (draw3) 0f else 30f).value,
           )
-          .clickable(onClick = { draw3 = !draw3 })
+          .clickable(onClick = { draw3 = !draw3 }),
     )
     Image(
       painter = painterResource(id = R.drawable.billie),
@@ -264,9 +264,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
           .graphicsLayer(
             shadowElevation = animateFloatAsState(if (draw3) 30f else 5f).value,
             translationY = animateFloatAsState(if (draw3) 0f else 50f).value,
-            rotationY = animateFloatAsState(if (draw3) 45f else 0f).value
+            rotationY = animateFloatAsState(if (draw3) 45f else 0f).value,
           )
-          .clickable(onClick = { draw3 = !draw3 })
+          .clickable(onClick = { draw3 = !draw3 }),
     )
   }
   Spacer(modifier = Modifier.padding(30.dp))
@@ -282,9 +282,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
             shadowElevation = animateFloatAsState(if (draw4) 30f else 5f).value,
             translationX = animateFloatAsState(if (draw4) 320f else 0f).value,
             rotationZ = animateFloatAsState(if (draw4) 45f else 0f).value,
-            translationY = 0f
+            translationY = 0f,
           )
-          .clickable(onClick = { draw4 = !draw4 })
+          .clickable(onClick = { draw4 = !draw4 }),
     )
     Image(
       painter = painterResource(id = R.drawable.khalid),
@@ -295,9 +295,9 @@ fun DrawLayerWithAnimateAsStateAnimations() {
             shadowElevation = animateFloatAsState(if (draw4) 30f else 10f).value,
             translationX = animateFloatAsState(if (draw4) -320f else 0f).value,
             rotationZ = animateFloatAsState(if (draw4) 45f else 0f).value,
-            translationY = animateFloatAsState(if (draw4) 0f else 30f).value
+            translationY = animateFloatAsState(if (draw4) 0f else 30f).value,
           )
-          .clickable(onClick = { draw4 = !draw4 })
+          .clickable(onClick = { draw4 = !draw4 }),
     )
     Image(
       painter = painterResource(id = R.drawable.camelia),
@@ -309,7 +309,7 @@ fun DrawLayerWithAnimateAsStateAnimations() {
             translationY = animateFloatAsState(if (draw4) 0f else 50f).value,
             rotationZ = animateFloatAsState(if (draw4) 45f else 0f).value,
           )
-          .clickable(onClick = { draw4 = !draw4 })
+          .clickable(onClick = { draw4 = !draw4 }),
     )
     Spacer(modifier = Modifier.padding(60.dp))
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/animation/AnimationScreen.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/animation/AnimationScreen.kt
@@ -29,7 +29,7 @@ import com.guru.composecookbook.ui.utils.TitleText
 enum class MyAnimationState {
   START,
   MID,
-  END
+  END,
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,22 +47,20 @@ fun AnimationScreen() {
               state = animateIcon,
               asset = Icons.Filled.PlayArrow,
               angle = 1440f,
-              duration = 3000
+              duration = 3000,
             )
           }
-        }
+        },
       )
     },
     content = { paddingValues ->
       AnimationScreenContent(modifier = Modifier.padding(paddingValues))
-    }
+    },
   )
 }
 
 @Composable
-fun AnimationScreenContent(
-  modifier: Modifier = Modifier,
-) {
+fun AnimationScreenContent(modifier: Modifier = Modifier) {
   LazyColumn(
     state = rememberLazyListState(),
     horizontalAlignment = Alignment.CenterHorizontally,
@@ -77,7 +75,7 @@ fun AnimationScreenContent(
     item { AnimationsWithVisibilityApi() }
     item { AnimatableSuspendedAnimations() }
     item { TransitionAnimationsWithMultipleStates() }
-    item { ColorPicker(onColorSelected = { /*TODO*/}) }
+    item { ColorPicker(onColorSelected = { /*TODO*/ }) }
     item { Spacer(modifier = Modifier.padding(100.dp)) }
   }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/animation/ModernAnimations.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/animation/ModernAnimations.kt
@@ -83,13 +83,13 @@ fun LikeButtonAnimation() {
         scale = 1f
       }
     },
-    modifier = Modifier.graphicsLayer(scaleX = scale, scaleY = scale)
+    modifier = Modifier.graphicsLayer(scaleX = scale, scaleY = scale),
   ) {
     Icon(
       Icons.Default.Favorite,
       contentDescription = "Like",
       tint = if (liked) Color.Red else Color.Gray,
-      modifier = Modifier.size(24.dp)
+      modifier = Modifier.size(24.dp),
     )
   }
 }
@@ -108,7 +108,7 @@ fun AnimatedCounter() {
           slideInVertically { it } + fadeIn() togetherWith
             slideOutVertically { -it } + fadeOut() using
             SizeTransform(clip = false)
-        }
+        },
       ) { targetCount ->
         Text("$targetCount")
       }
@@ -126,8 +126,8 @@ fun ShimmerLoadingAnimation() {
       animationSpec =
         infiniteRepeatable(
           animation = tween(1500, easing = LinearOutSlowInEasing),
-          repeatMode = RepeatMode.Restart
-        )
+          repeatMode = RepeatMode.Restart,
+        ),
     )
 
   Box(
@@ -141,7 +141,7 @@ fun ShimmerLoadingAnimation() {
             androidx.compose.ui.graphics.Brush.linearGradient(
               colors = listOf(Color.Transparent, Color.White.copy(alpha = 0.4f), Color.Transparent),
               start = androidx.compose.ui.geometry.Offset(translateAnim.value - 500f, 0f),
-              end = androidx.compose.ui.geometry.Offset(translateAnim.value, 500f)
+              end = androidx.compose.ui.geometry.Offset(translateAnim.value, 500f),
             )
         )
   )
@@ -157,8 +157,8 @@ fun PulseAnimation() {
       animationSpec =
         infiniteRepeatable(
           animation = tween(1000, easing = EaseInOut),
-          repeatMode = RepeatMode.Reverse
-        )
+          repeatMode = RepeatMode.Reverse,
+        ),
     )
 
   Box(
@@ -191,8 +191,8 @@ fun WaveLoadingAnimation() {
                   1f at 600 with LinearOutSlowInEasing
                   0f at 1200 with LinearOutSlowInEasing
                 },
-              initialStartOffset = androidx.compose.animation.core.StartOffset(delay)
-            )
+              initialStartOffset = androidx.compose.animation.core.StartOffset(delay),
+            ),
         )
 
       Box(

--- a/app/src/main/java/com/guru/composecookbook/ui/animation/TransitionsAnimations.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/animation/TransitionsAnimations.kt
@@ -58,10 +58,7 @@ fun MultiStateColorPositionAnimation() {
   val transition = updateTransition(targetState = animationState, label = "transition")
 
   val animatedColor by
-    transition.animateColor(
-      transitionSpec = { tween(500) },
-      label = "animatedColor",
-    ) { state ->
+    transition.animateColor(transitionSpec = { tween(500) }, label = "animatedColor") { state ->
       when (state) {
         MyAnimationState.START -> startColor
         MyAnimationState.MID -> midColor
@@ -70,10 +67,7 @@ fun MultiStateColorPositionAnimation() {
     }
 
   val position by
-    transition.animateDp(
-      transitionSpec = { tween(500) },
-      label = "position",
-    ) { state ->
+    transition.animateDp(transitionSpec = { tween(500) }, label = "position") { state ->
       when (state) {
         MyAnimationState.START -> 0.dp
         MyAnimationState.MID -> 80.dp
@@ -90,7 +84,7 @@ fun MultiStateColorPositionAnimation() {
           MyAnimationState.MID -> MyAnimationState.END
           MyAnimationState.END -> MyAnimationState.START
         }
-    }
+    },
   ) {
     Icon(imageVector = Icons.Default.PlayCircleFilled, contentDescription = null)
   }
@@ -109,20 +103,20 @@ fun MultiStateInfiniteTransition() {
     transition.animateColor(
       initialValue = startColor,
       targetValue = endColor,
-      animationSpec = infiniteRepeatable(tween(800), RepeatMode.Reverse)
+      animationSpec = infiniteRepeatable(tween(800), RepeatMode.Reverse),
     )
 
   val position by
     transition.animateFloat(
       initialValue = -80f,
       targetValue = 80f,
-      animationSpec = infiniteRepeatable(tween(800), RepeatMode.Reverse)
+      animationSpec = infiniteRepeatable(tween(800), RepeatMode.Reverse),
     )
 
   FloatingActionButton(
     containerColor = animatedColor,
     modifier = Modifier.offset(x = position.dp),
-    onClick = {}
+    onClick = {},
   ) {
     Icon(imageVector = Icons.Default.PlayCircleFilled, contentDescription = null)
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/animation/VisibilityAnimations.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/animation/VisibilityAnimations.kt
@@ -103,7 +103,7 @@ fun AnimateVisibilityWithDifferentChildAnimations() {
           modifier =
             Modifier.size(80.dp)
               .padding(8.dp)
-              .animateEnterExit(enter = slideInHorizontally { it }, exit = ExitTransition.None)
+              .animateEnterExit(enter = slideInHorizontally { it }, exit = ExitTransition.None),
         ) {}
       }
     }
@@ -127,7 +127,7 @@ fun VisibilityAnimationWithShrinkExpand() {
       visibility,
       modifier = Modifier.align(Alignment.CenterVertically),
       enter = expandIn(expandFrom = Alignment.Center) { it -> it * 4 },
-      exit = shrinkOut(shrinkTowards = Alignment.Center) { it -> it }
+      exit = shrinkOut(shrinkTowards = Alignment.Center) { it -> it },
     ) {
       Button(modifier = Modifier.padding(start = 12.dp), onClick = { visibility = !visibility }) {
         Text(text = "Shrink/Expand")
@@ -152,12 +152,7 @@ fun AnimateVisibilityWithSlideInOutSample() {
       visibility,
       enter =
         slideIn(tween(easing = LinearOutSlowInEasing, durationMillis = 500)) { IntOffset(0, 120) },
-      exit =
-        slideOut(
-          tween(500, easing = FastOutSlowInEasing),
-        ) {
-          IntOffset(0, 120)
-        }
+      exit = slideOut(tween(500, easing = FastOutSlowInEasing)) { IntOffset(0, 120) },
     ) {
       // Content that needs to appear/disappear goes here:
       Text("Tap for Sliding animation")

--- a/app/src/main/java/com/guru/composecookbook/ui/demoapps/DemoUIList.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/demoapps/DemoUIList.kt
@@ -80,11 +80,11 @@ fun DemoUIList() {
                 else -> TODO("Create your activity to launch any new demo app")
               }
             },
-            modifier = Modifier.fillMaxWidth().padding(12.dp)
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
           ) {
             Text(text = title, modifier = Modifier.padding(8.dp))
           }
-        }
+        },
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/HomeScreen.kt
@@ -75,7 +75,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun HomeScreen(
   appThemeState: MutableState<AppThemeState>,
-  chooseColorBottomModalState: ModalBottomSheetState
+  chooseColorBottomModalState: ModalBottomSheetState,
 ) {
   val showMenu = remember { mutableStateOf(false) }
   val coroutineScope = rememberCoroutineScope()
@@ -95,7 +95,7 @@ fun HomeScreen(
             Icon(
               painter = painterResource(id = R.drawable.ic_sleep),
               contentDescription =
-                stringResource(id = com.guru.composecookbook.R.string.cd_dark_theme)
+                stringResource(id = com.guru.composecookbook.R.string.cd_dark_theme),
             )
           }
           ChangeColorIconButton(coroutineScope, chooseColorBottomModalState, showMenu)
@@ -112,9 +112,9 @@ fun HomeScreen(
           // we are just passing to till HomeScreen.
           appThemeState.value = appThemeState.value.copy(pallet = newPalletSelected)
           showMenu.value = false
-        }
+        },
       )
-    }
+    },
   )
 }
 
@@ -124,7 +124,7 @@ fun HomeScreen(
 private fun ChangeColorIconButton(
   coroutineScope: CoroutineScope,
   chooseColorBottomModalState: ModalBottomSheetState,
-  showMenu: MutableState<Boolean>
+  showMenu: MutableState<Boolean>,
 ) {
   val accessibilityManager =
     LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE)
@@ -142,7 +142,7 @@ private fun ChangeColorIconButton(
   ) {
     Icon(
       imageVector = Icons.Default.Palette,
-      contentDescription = stringResource(id = com.guru.composecookbook.R.string.cd_change_color)
+      contentDescription = stringResource(id = com.guru.composecookbook.R.string.cd_change_color),
     )
   }
 }
@@ -169,7 +169,7 @@ fun HomeScreenContent(
       LazyColumn(modifier = Modifier.testTag(TestTags.HOME_SCREEN_LIST)) {
         items(
           items = list,
-          itemContent = { HomeScreenListView(it, context, isDarkTheme, isWiderScreen) }
+          itemContent = { HomeScreenListView(it, context, isDarkTheme, isWiderScreen) },
         )
       }
     }
@@ -203,7 +203,7 @@ fun PalletMenu(modifier: Modifier, onPalletChange: (ColorPallet) -> Unit) {
 fun MenuItem(color: Color, name: String, onPalletChange: () -> Unit) {
   Row(
     modifier = Modifier.padding(8.dp).clickable(onClick = onPalletChange),
-    verticalAlignment = Alignment.CenterVertically
+    verticalAlignment = Alignment.CenterVertically,
   ) {
     Icon(imageVector = Icons.Filled.FiberManualRecord, tint = color, contentDescription = null)
     Text(text = name, modifier = Modifier.padding(8.dp))
@@ -215,7 +215,7 @@ fun HomeScreenListView(
   homeScreenItems: HomeScreenItems,
   context: Context,
   isDarkTheme: Boolean,
-  isWiderScreen: Boolean
+  isWiderScreen: Boolean,
 ) {
   if (isWiderScreen) {
     Material3Card(
@@ -226,23 +226,23 @@ fun HomeScreenListView(
       backgroundColor = MaterialTheme.colorScheme.primary,
       shape = RoundedCornerShape(8.dp),
       elevation = 4.dp,
-      contentColor = MaterialTheme.colorScheme.onPrimary
+      contentColor = MaterialTheme.colorScheme.onPrimary,
     ) {
       Text(
         text = homeScreenItems.name,
         modifier = Modifier.padding(8.dp),
-        style = MaterialTheme.typography.titleMedium
+        style = MaterialTheme.typography.titleMedium,
       )
     }
   } else {
     Button(
       onClick = { homeItemClicked(homeScreenItems, context, isDarkTheme) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("button-${homeScreenItems.name}")
+      modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("button-${homeScreenItems.name}"),
     ) {
       Text(
         text = homeScreenItems.name,
         modifier = Modifier.padding(8.dp),
-        style = MaterialTheme.typography.labelLarge
+        style = MaterialTheme.typography.labelLarge,
       )
     }
   }
@@ -256,7 +256,7 @@ fun homeItemClicked(homeScreenItems: HomeScreenItems, context: Context, isDarkTh
         ListViewActivity.newIntent(
           context,
           homeScreenItems.type.uppercase(Locale.getDefault()),
-          isDarkTheme
+          isDarkTheme,
         )
       }
       HomeScreenItems.Dialogs -> {

--- a/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/AdvanceListsActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/AdvanceListsActivity.kt
@@ -55,16 +55,14 @@ class AdvanceListsActivity : ComponentActivity() {
                 IconButton(onClick = { onBackPressed() }) {
                   Icon(
                     Icons.Filled.ArrowBack,
-                    contentDescription = stringResource(id = R.string.cd_back)
+                    contentDescription = stringResource(id = R.string.cd_back),
                   )
                 }
-              }
+              },
             )
           }
         ) { paddingValues ->
-          AdvanceListContent(
-            modifier = Modifier.padding(paddingValues),
-          )
+          AdvanceListContent(modifier = Modifier.padding(paddingValues))
         }
       }
     }
@@ -73,22 +71,21 @@ class AdvanceListsActivity : ComponentActivity() {
   companion object {
     val tabs = listOf("Shimmers", "Animated Lists", "Swipeable Lists")
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, isDarkTheme: Boolean) =
       Intent(context, AdvanceListsActivity::class.java).apply { putExtra(DARK_THEME, isDarkTheme) }
   }
 }
 
 @Composable
-fun AdvanceListContent(
-  modifier: Modifier = Modifier,
-) {
+fun AdvanceListContent(modifier: Modifier = Modifier) {
   var selectedIndex by remember { mutableStateOf(0) }
   val pagerState: PagerState = run { remember { PagerState(0, 0, tabs.size - 1) } }
   Column(modifier = modifier) {
     ScrollableTabRow(
       backgroundColor = MaterialTheme.colorScheme.surface,
       selectedTabIndex = selectedIndex,
-      edgePadding = 12.dp
+      edgePadding = 12.dp,
     ) {
       tabs.forEachIndexed { index, title ->
         Tab(
@@ -97,7 +94,7 @@ fun AdvanceListContent(
             selectedIndex = tabs.indexOf(title)
             pagerState.currentPage = tabs.indexOf(title)
           },
-          text = { Text(title) }
+          text = { Text(title) },
         )
       }
     }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/AnimatedLists.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/AnimatedLists.kt
@@ -50,14 +50,14 @@ fun AnimatedLists() {
         YoutubeChip(
           selected = index == animationIndex,
           text = title,
-          modifier = Modifier.padding(8.dp).clickable(onClick = { animationIndex = index })
+          modifier = Modifier.padding(8.dp).clickable(onClick = { animationIndex = index }),
         )
       }
     }
     LazyColumn {
       itemsIndexed(
         items = tweets,
-        itemContent = { index, tweet -> AnimatedListItem(tweet = tweet, index, animationIndex) }
+        itemContent = { index, tweet -> AnimatedListItem(tweet = tweet, index, animationIndex) },
       )
     }
   }
@@ -80,7 +80,7 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         LaunchedEffect(Unit) {
           animatedProgress.animateTo(
             targetValue = 1f,
-            animationSpec = tween(300, easing = LinearEasing)
+            animationSpec = tween(300, easing = LinearEasing),
           )
         }
         Modifier.padding(8.dp)
@@ -91,7 +91,7 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         LaunchedEffect(Unit) {
           animatedProgress.animateTo(
             targetValue = 0f,
-            animationSpec = tween(300, easing = FastOutSlowInEasing)
+            animationSpec = tween(300, easing = FastOutSlowInEasing),
           )
         }
         Modifier.padding(8.dp).graphicsLayer(translationX = animatedProgress.value)
@@ -102,7 +102,7 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         LaunchedEffect(Unit) {
           animatedProgress.animateTo(
             targetValue = 0f,
-            animationSpec = tween(300, easing = LinearEasing)
+            animationSpec = tween(300, easing = LinearEasing),
           )
           opacityProgress.animateTo(targetValue = 1f, animationSpec = tween(600))
         }
@@ -116,7 +116,7 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         LaunchedEffect(Unit) {
           animatedProgress.animateTo(
             targetValue = 0f,
-            animationSpec = tween(300, easing = LinearEasing)
+            animationSpec = tween(300, easing = LinearEasing),
           )
           opacityProgress.animateTo(targetValue = 1f, animationSpec = tween(600))
         }
@@ -129,7 +129,7 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         LaunchedEffect(Unit) {
           animatedProgress.animateTo(
             targetValue = 360f,
-            animationSpec = tween(400, easing = FastOutSlowInEasing)
+            animationSpec = tween(400, easing = FastOutSlowInEasing),
           )
         }
         Modifier.padding(8.dp).graphicsLayer(rotationX = animatedProgress.value)
@@ -142,10 +142,7 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         Modifier.padding(8.dp).alpha(animatedProgress.value)
       }
     }
-  Row(
-    modifier = animatedModifier,
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
+  Row(modifier = animatedModifier, verticalAlignment = Alignment.CenterVertically) {
     Image(
       painter =
         rememberImagePainter(
@@ -157,26 +154,26 @@ fun AnimatedListItem(tweet: Tweet, itemIndex: Int, animationIndex: Int) {
         ),
       contentDescription = null,
       contentScale = ContentScale.Crop,
-      modifier = Modifier.size(55.dp).padding(4.dp)
+      modifier = Modifier.size(55.dp).padding(4.dp),
     )
     Column(modifier = Modifier.padding(horizontal = 4.dp).weight(1f)) {
       Text(
         text = tweet.author,
         style = typography.h6.copy(fontSize = 16.sp),
-        color = MaterialTheme.colorScheme.onSurface
+        color = MaterialTheme.colorScheme.onSurface,
       )
       Text(
         text = tweet.text,
         style = typography.subtitle2,
         maxLines = 1,
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
     }
     Icon(
       imageVector = Icons.Default.MoreVert,
       contentDescription = null,
       tint = Color.LightGray,
-      modifier = Modifier.padding(4.dp)
+      modifier = Modifier.padding(4.dp),
     )
   }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/Shimmer.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/Shimmer.kt
@@ -40,7 +40,7 @@ enum class ShimmerAnimationType {
   FADE,
   TRANSLATE,
   FADETRANSLATE,
-  VERTICAL
+  VERTICAL,
 }
 
 @Preview
@@ -54,7 +54,7 @@ fun ShimmerList() {
       initialValue = 100f,
       targetValue = 600f,
       animationSpec =
-        infiniteRepeatable(tween(durationMillis = 1200, easing = LinearEasing), RepeatMode.Restart)
+        infiniteRepeatable(tween(durationMillis = 1200, easing = LinearEasing), RepeatMode.Restart),
     )
 
   val colorAnim by
@@ -64,8 +64,8 @@ fun ShimmerList() {
       animationSpec =
         infiniteRepeatable(
           tween(durationMillis = 1200, easing = FastOutSlowInEasing),
-          RepeatMode.Restart
-        )
+          RepeatMode.Restart,
+        ),
     )
 
   val list =
@@ -92,38 +92,38 @@ fun ShimmerList() {
   Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
     Row(
       horizontalArrangement = Arrangement.SpaceAround,
-      modifier = Modifier.fillMaxWidth().padding(8.dp)
+      modifier = Modifier.fillMaxWidth().padding(8.dp),
     ) {
       Button(
         onClick = { shimmerAnimationType = ShimmerAnimationType.FADE },
         colors = buttonColors(ShimmerAnimationType.FADE),
-        modifier = Modifier.width(200.dp).padding(8.dp)
+        modifier = Modifier.width(200.dp).padding(8.dp),
       ) {
         Text(text = "Fading")
       }
       Button(
         onClick = { shimmerAnimationType = ShimmerAnimationType.TRANSLATE },
         colors = buttonColors(ShimmerAnimationType.TRANSLATE),
-        modifier = Modifier.width(200.dp).padding(8.dp)
+        modifier = Modifier.width(200.dp).padding(8.dp),
       ) {
         Text(text = "Translating")
       }
     }
     Row(
       horizontalArrangement = Arrangement.SpaceAround,
-      modifier = Modifier.fillMaxWidth().padding(8.dp)
+      modifier = Modifier.fillMaxWidth().padding(8.dp),
     ) {
       Button(
         onClick = { shimmerAnimationType = ShimmerAnimationType.FADETRANSLATE },
         colors = buttonColors(ShimmerAnimationType.FADETRANSLATE),
-        modifier = Modifier.width(200.dp).padding(8.dp)
+        modifier = Modifier.width(200.dp).padding(8.dp),
       ) {
         Text(text = "Fade+Translate")
       }
       Button(
         onClick = { shimmerAnimationType = ShimmerAnimationType.VERTICAL },
         colors = buttonColors(ShimmerAnimationType.VERTICAL),
-        modifier = Modifier.width(200.dp).padding(8.dp)
+        modifier = Modifier.width(200.dp).padding(8.dp),
       ) {
         Text(text = "Vertical")
       }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/SwipeableLists.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/advancelists/SwipeableLists.kt
@@ -23,7 +23,7 @@ fun SwipeableLists() {
   LazyColumn {
     itemsIndexed(
       items = albums,
-      itemContent = { index, album -> SwipeableListItem(index, album) { index -> } }
+      itemContent = { index, album -> SwipeableListItem(index, album) { index -> } },
     )
   }
 }
@@ -51,18 +51,18 @@ fun SwipeableListItem(index: Int, album: Album, onItemSwiped: (Int) -> Unit) {
           Modifier.fillMaxSize()
             .background(MaterialTheme.colorScheme.errorContainer)
             .padding(horizontal = 16.dp),
-        contentAlignment = Alignment.CenterEnd
+        contentAlignment = Alignment.CenterEnd,
       ) {
         Icon(
           imageVector = Icons.Default.Delete,
           contentDescription = "Delete",
-          tint = MaterialTheme.colorScheme.onErrorContainer
+          tint = MaterialTheme.colorScheme.onErrorContainer,
         )
       }
     },
     content = { ListItemContent(album) },
     enableDismissFromStartToEnd = false,
-    enableDismissFromEndToStart = true
+    enableDismissFromEndToStart = true,
   )
 }
 
@@ -72,20 +72,20 @@ private fun ListItemContent(album: Album) {
     Row(
       modifier = Modifier.fillMaxWidth().padding(16.dp),
       horizontalArrangement = Arrangement.spacedBy(16.dp),
-      verticalAlignment = Alignment.CenterVertically
+      verticalAlignment = Alignment.CenterVertically,
     ) {
       Column(modifier = Modifier.weight(1f)) {
         Text(
           text = album.song,
           style = MaterialTheme.typography.titleMedium,
           maxLines = 1,
-          overflow = TextOverflow.Ellipsis
+          overflow = TextOverflow.Ellipsis,
         )
         Text(
           text = album.artist,
           style = MaterialTheme.typography.bodyMedium,
           maxLines = 1,
-          overflow = TextOverflow.Ellipsis
+          overflow = TextOverflow.Ellipsis,
         )
       }
       IconButton(onClick = {}) {

--- a/app/src/main/java/com/guru/composecookbook/ui/home/androidviews/AndroidViews.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/androidviews/AndroidViews.kt
@@ -124,7 +124,7 @@ fun AndroidMapView() {
 private fun MapViewContainer(map: MapView, latitude: String, longitude: String) {
   AndroidView<MapView>(
     factory = { map },
-    modifier = Modifier.fillMaxWidth().height(400.dp).padding(8.dp).clip(RoundedCornerShape(10.dp))
+    modifier = Modifier.fillMaxWidth().height(400.dp).padding(8.dp).clip(RoundedCornerShape(10.dp)),
   ) { mapView ->
     mapView.getMapAsync { googleMap ->
       val position = LatLng(latitude.toDouble(), longitude.toDouble())

--- a/app/src/main/java/com/guru/composecookbook/ui/home/clock/ClockDemo.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/clock/ClockDemo.kt
@@ -25,7 +25,7 @@ fun ClockDemo(viewModel: ClockViewModel = androidx.lifecycle.viewmodel.compose.v
     Column(
       modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(16.dp),
       verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       ClockView(
         hourAngle = clockState.first,
@@ -34,7 +34,7 @@ fun ClockDemo(viewModel: ClockViewModel = androidx.lifecycle.viewmodel.compose.v
         modifier =
           Modifier.height(200.dp)
             .width(200.dp)
-            .background(color = MaterialTheme.colors.surface, shape = CircleShape)
+            .background(color = MaterialTheme.colors.surface, shape = CircleShape),
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/clock/ClockView.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/clock/ClockView.kt
@@ -21,7 +21,7 @@ fun ClockView(
   textColor: Color = MaterialTheme.colors.onSurface,
   hourHandColor: Color = MaterialTheme.colors.onSurface,
   minuteHandColor: Color = MaterialTheme.colors.onSurface,
-  secondHandColor: Color = MaterialTheme.colors.onSurface
+  secondHandColor: Color = MaterialTheme.colors.onSurface,
 ) {
   Canvas(modifier = modifier) {
     // Outer Circle
@@ -39,12 +39,12 @@ fun ClockView(
         start =
           Offset(
             (origin + (lineInnerR * xRad)).toFloat(),
-            (origin + (lineInnerR * yRad)).toFloat()
+            (origin + (lineInnerR * yRad)).toFloat(),
           ),
         end =
           Offset(
             (origin + (lineOuterR * xRad)).toFloat(),
-            (origin + (lineOuterR * yRad)).toFloat()
+            (origin + (lineOuterR * yRad)).toFloat(),
           ),
         strokeWidth = 2.dp.toPx(),
         cap = StrokeCap.Round,
@@ -68,7 +68,7 @@ fun ClockView(
       end =
         Offset((origin + (rHour * xRadHour)).toFloat(), (origin + (rHour * yRadHour)).toFloat()),
       strokeWidth = 3.dp.toPx(),
-      cap = StrokeCap.Round
+      cap = StrokeCap.Round,
     )
 
     // Minute Hand
@@ -81,10 +81,10 @@ fun ClockView(
       end =
         Offset(
           (origin + (rMinute * xRadMinute)).toFloat(),
-          (origin + (rMinute * yRadMinute)).toFloat()
+          (origin + (rMinute * yRadMinute)).toFloat(),
         ),
       strokeWidth = 2.dp.toPx(),
-      cap = StrokeCap.Round
+      cap = StrokeCap.Round,
     )
 
     // Second Hand
@@ -97,10 +97,10 @@ fun ClockView(
       end =
         Offset(
           (origin + (rSecond * xRadSecond)).toFloat(),
-          (origin + (rSecond * yRadSecond)).toFloat()
+          (origin + (rSecond * yRadSecond)).toFloat(),
         ),
       strokeWidth = 1.dp.toPx(),
-      cap = StrokeCap.Round
+      cap = StrokeCap.Round,
     )
   }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/constraintlayout/ConstraintLayoutDemos.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/constraintlayout/ConstraintLayoutDemos.kt
@@ -66,7 +66,7 @@ fun ConstraintLayoutListItem() {
         Modifier.size(120.dp).clip(CircleShape).constrainAs(image) {
           linkTo(top = parent.top, topMargin = 16.dp, bottom = parent.bottom, bottomMargin = 16.dp)
           linkTo(start = parent.start, end = title.start)
-        }
+        },
     )
     Text(
       text = item.title,
@@ -75,7 +75,7 @@ fun ConstraintLayoutListItem() {
         Modifier.constrainAs(title) {
           linkTo(start = image.end, startMargin = 16.dp, end = button.start, endMargin = 16.dp)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = item.subtitle,
@@ -84,7 +84,7 @@ fun ConstraintLayoutListItem() {
         Modifier.constrainAs(subtitle) {
           linkTo(start = title.start, end = parent.end)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Spacer(
       Modifier.height(8.dp).constrainAs(space) {
@@ -98,7 +98,7 @@ fun ConstraintLayoutListItem() {
         Modifier.constrainAs(source) {
           start.linkTo(title.start)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     IconButton(
       onClick = {},
@@ -106,7 +106,7 @@ fun ConstraintLayoutListItem() {
         Modifier.constrainAs(button) {
           linkTo(top = title.top, bottom = title.bottom)
           linkTo(start = title.end, end = parent.end, endMargin = 8.dp)
-        }
+        },
     ) {
       Icon(Icons.Default.FavoriteBorder, contentDescription = null)
     }
@@ -126,12 +126,9 @@ fun ConstraintLayoutBigListItem() {
       contentScale = ContentScale.Crop,
       modifier =
         Modifier.height(200.dp).constrainAs(image) {
-          linkTo(
-            start = parent.start,
-            end = parent.end,
-          )
+          linkTo(start = parent.start, end = parent.end)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = item.title,
@@ -141,7 +138,7 @@ fun ConstraintLayoutBigListItem() {
           linkTo(start = parent.start, startMargin = 16.dp, end = parent.end, endMargin = 16.dp)
           linkTo(top = image.bottom, topMargin = 8.dp, bottom = subtitle.top)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = item.subtitle,
@@ -150,7 +147,7 @@ fun ConstraintLayoutBigListItem() {
         Modifier.constrainAs(subtitle) {
           linkTo(start = title.start, end = title.end)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = item.source,
@@ -160,7 +157,7 @@ fun ConstraintLayoutBigListItem() {
           start.linkTo(title.start)
           linkTo(top = subtitle.bottom, bottom = parent.bottom)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     IconButton(
       onClick = {},
@@ -168,7 +165,7 @@ fun ConstraintLayoutBigListItem() {
         Modifier.constrainAs(button) {
           top.linkTo(parent.top, margin = 8.dp)
           end.linkTo(parent.end, margin = 8.dp)
-        }
+        },
     ) {
       Icon(Icons.Default.FavoriteBorder, contentDescription = null)
     }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/FlingListActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/FlingListActivity.kt
@@ -73,7 +73,7 @@ class FlingListActivity : ComponentActivity() {
              * to the previous page.
              */
             onBackPressed()
-          }
+          },
         ) {
           // Opens the settings activity.
           openSettings()
@@ -92,7 +92,7 @@ class FlingListActivity : ComponentActivity() {
         Toast.makeText(
             this,
             "Your settings was not saved, please click on apply in the settings page to test the custom fling behaviour",
-            Toast.LENGTH_SHORT
+            Toast.LENGTH_SHORT,
           )
           .show()
       }
@@ -132,7 +132,7 @@ fun ListViewContent(
   list: List<Item>,
   flingStateStore: State<FlingStateStore>,
   onBack: () -> Unit,
-  onSettingsClick: () -> Unit
+  onSettingsClick: () -> Unit,
 ) {
   /*
    * This is done to match up the designs of the present page with the other pages of the App.
@@ -153,7 +153,7 @@ fun ListViewContent(
           IconButton(onClick = onBack) {
             Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(id = R.string.cd_back))
           }
-        }
+        },
       )
     },
     content = { paddingValues ->
@@ -163,7 +163,7 @@ fun ListViewContent(
         onSettingsClick = onSettingsClick,
         modifier = Modifier.padding(paddingValues),
       )
-    }
+    },
   )
 }
 

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/FlingListSettingsActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/FlingListSettingsActivity.kt
@@ -99,15 +99,12 @@ fun SettingsContent(onback: () -> Unit, onApply: () -> Unit) {
           IconButton(onClick = onback) {
             Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(id = R.string.cd_back))
           }
-        }
+        },
       )
     },
     content = { paddingValues ->
-      RenderSettingsPage(
-        onApplyClick = onApply,
-        modifier = Modifier.padding(paddingValues),
-      )
-    }
+      RenderSettingsPage(onApplyClick = onApply, modifier = Modifier.padding(paddingValues))
+    },
   )
 }
 

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/FlingStateStore.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/FlingStateStore.kt
@@ -20,7 +20,7 @@ data class FlingStateStore(
   var splineInflection: Float = 0.1f,
   var splineStartTension: Float = 0.1f,
   var splineEndTension: Float = 1.0f,
-  var numberOfSplinePoints: Int = 100
+  var numberOfSplinePoints: Int = 100,
 ) {
   companion object {
     var INSTANCE = FlingStateStore()

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/ListItemDivider.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/ListItemDivider.kt
@@ -12,6 +12,6 @@ import androidx.compose.ui.unit.dp
 fun ListItemDivider() {
   Divider(
     modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
-    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
   )
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/SettingsPage.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/SettingsPage.kt
@@ -46,10 +46,7 @@ import com.guru.composecookbook.ui.utils.toFloatNum
 
 /** Entry point. */
 @Composable
-fun RenderSettingsPage(
-  onApplyClick: () -> Unit,
-  modifier: Modifier = Modifier,
-) {
+fun RenderSettingsPage(onApplyClick: () -> Unit, modifier: Modifier = Modifier) {
   // Heading.
   Column(modifier = modifier.fillMaxHeight().fillMaxWidth()) {
 
@@ -75,7 +72,7 @@ fun RenderSettingsPage(
 fun BuildRadioSelectionPage(
   radioSelection: MutableState<String>,
   flingCopyStore: FlingStateStore,
-  onApplyClick: () -> Unit
+  onApplyClick: () -> Unit,
 ) {
   /*
    * Build EditTexts if the user is selecting the custom radio button.
@@ -94,14 +91,14 @@ fun DrawApplyButton(onApplyClick: () -> Unit, flingCopyStore: FlingStateStore) {
   Column(
     modifier = Modifier.fillMaxWidth().height(60.dp),
     verticalArrangement = Arrangement.Center,
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     Button(
       onClick = {
         FlingStateStore.INSTANCE = flingCopyStore
         onApplyClick()
       },
-      modifier = Modifier.size(200.dp, 60.dp).testTag(TestTags.HOME_FLING_SETTINGS_APPLY)
+      modifier = Modifier.size(200.dp, 60.dp).testTag(TestTags.HOME_FLING_SETTINGS_APPLY),
     ) {
       Text(text = "Apply")
     }
@@ -125,14 +122,14 @@ fun BuildRadioButton(radioSelection: MutableState<String>, flingCopyStore: Fling
           }
         }
       radioSelection.value = selection
-    }
+    },
   )
 }
 
 @Composable
 fun BuildEditTexts(
   /* apply callback */ onApplyClick: () -> Unit,
-  /* Fling Behaviour clone */ flingCopyStore: FlingStateStore
+  /* Fling Behaviour clone */ flingCopyStore: FlingStateStore,
 ) {
   // Used to update the scrollFriction EditText
   val scrollFriction = remember { mutableStateOf(flingCopyStore.scrollFriction.toString()) }
@@ -180,14 +177,14 @@ fun BuildEditTexts(
   Row(
     horizontalArrangement = Arrangement.Center,
     verticalAlignment = Alignment.CenterVertically,
-    modifier = Modifier.height(100.dp).testTag(TestTags.HOME_FLING_SETTINGS_EDITABLE)
+    modifier = Modifier.height(100.dp).testTag(TestTags.HOME_FLING_SETTINGS_EDITABLE),
   ) {
     Column(modifier = Modifier.weight(1f).padding(10.dp, 0.dp, 0.dp, 10.dp).width(100.dp)) {
       Text(
         text = "Scroll Friction",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = scrollFriction.value,
@@ -196,7 +193,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -213,7 +210,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
     Column(modifier = Modifier.weight(1f).padding(10.dp, 0.dp, 0.dp, 10.dp).width(100.dp)) {
@@ -221,7 +218,7 @@ fun BuildEditTexts(
         text = "absVelocityThreshold",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = absVelocityThreshold.value,
@@ -230,7 +227,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -256,7 +253,7 @@ fun BuildEditTexts(
         text = "gravitationalForce",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = gravitationalForce.value,
@@ -265,7 +262,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -282,7 +279,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
   }
@@ -293,7 +290,7 @@ fun BuildEditTexts(
         text = "inchesPerMeter",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = inchesPerMeter.value,
@@ -302,7 +299,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -319,7 +316,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
     Column(modifier = Modifier.weight(1f).padding(10.dp, 0.dp, 0.dp, 10.dp).width(100.dp)) {
@@ -327,7 +324,7 @@ fun BuildEditTexts(
         text = "decelerationFriction",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = decelerationFriction.value,
@@ -336,7 +333,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -362,7 +359,7 @@ fun BuildEditTexts(
         text = "decelerationRate",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = decelerationRate.value,
@@ -371,7 +368,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -388,7 +385,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
   }
@@ -399,7 +396,7 @@ fun BuildEditTexts(
         text = "splineInflection",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = splineInflection.value,
@@ -408,7 +405,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -425,7 +422,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
     Column(modifier = Modifier.weight(1f).padding(10.dp, 0.dp, 0.dp, 10.dp).width(100.dp)) {
@@ -433,7 +430,7 @@ fun BuildEditTexts(
         text = "splineStartTension",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = splineStartTension.value,
@@ -442,7 +439,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -468,7 +465,7 @@ fun BuildEditTexts(
         text = "splineEndTension",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = splineEndTension.value,
@@ -477,7 +474,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -494,7 +491,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
   }
@@ -505,7 +502,7 @@ fun BuildEditTexts(
         text = "numberOfSplinePoints",
         maxLines = 1,
         style = typography.caption.copy(fontSize = 10.sp),
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
       OutlinedTextField(
         value = numberOfSplinePoints.value,
@@ -514,7 +511,7 @@ fun BuildEditTexts(
         keyboardOptions =
           KeyboardOptions.Default.copy(
             imeAction = ImeAction.Done,
-            keyboardType = KeyboardType.Number
+            keyboardType = KeyboardType.Number,
           ),
         onValueChange = {
           when {
@@ -531,7 +528,7 @@ fun BuildEditTexts(
             }
           }
         },
-        modifier = Modifier.width(100.dp)
+        modifier = Modifier.width(100.dp),
       )
     }
   }
@@ -539,14 +536,14 @@ fun BuildEditTexts(
   Column(
     modifier = Modifier.fillMaxWidth().height(60.dp),
     verticalArrangement = Arrangement.Center,
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     Button(
       onClick = {
         FlingStateStore.INSTANCE = flingCopyStore
         onApplyClick()
       },
-      modifier = Modifier.size(200.dp, 60.dp).testTag(TestTags.HOME_FLING_SETTINGS_APPLY)
+      modifier = Modifier.size(200.dp, 60.dp).testTag(TestTags.HOME_FLING_SETTINGS_APPLY),
     ) {
       Text(text = "apply")
     }
@@ -559,7 +556,7 @@ fun radioGroup(
   radioOptions: List<String> = listOf(),
   title: String = "",
   flingCopyStore: FlingStateStore,
-  onItemSelection: (selection: String) -> Unit
+  onItemSelection: (selection: String) -> Unit,
 ): String {
   if (radioOptions.isNotEmpty()) {
     val selectedOption = remember { mutableStateOf(radioOptions[flingCopyStore.type.ordinal]) }
@@ -574,13 +571,8 @@ fun radioGroup(
       elevation = 8.dp,
       shape = RoundedCornerShape(8.dp),
     ) {
-      Row(
-        modifier = Modifier.padding(10.dp),
-      ) {
-        Text(
-          text = title,
-          modifier = Modifier.padding(5.dp),
-        )
+      Row(modifier = Modifier.padding(10.dp)) {
+        Text(text = title, modifier = Modifier.padding(5.dp))
 
         radioOptions.forEach { item ->
           Row(Modifier.padding(5.dp).weight(1f), verticalAlignment = Alignment.CenterVertically) {
@@ -588,7 +580,7 @@ fun radioGroup(
               selected = (item == selectedOption.value),
               onClick = { onOptionSelected(item) },
               colors = RadioButtonDefaults.colors(selectedColor = MaterialTheme.colors.primary),
-              modifier = Modifier.testTag(item)
+              modifier = Modifier.testTag(item),
             )
 
             Text(text = item, modifier = Modifier.clickable { onOptionSelected(item) })

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/VerticalFlingerList.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/VerticalFlingerList.kt
@@ -47,7 +47,7 @@ fun VerticalFlingerListView(
           // Click event callback.
           onSettingsClick()
         },
-        modifier = Modifier.size(100.dp, 40.dp)
+        modifier = Modifier.size(100.dp, 40.dp),
       ) {
         Text(text = "Settings", modifier = Modifier.testTag(TestTags.HOME_FLING_SETTINGS_BUTTON))
       }
@@ -77,14 +77,14 @@ fun RenderListWithBehaviour(list: List<Item>, flingBehavior: FlingBehavior) {
   LazyColumn(
     // Custom Fling behaviour
     flingBehavior = flingBehavior,
-    modifier = Modifier.testTag(TestTags.HOME_FLING_LIST)
+    modifier = Modifier.testTag(TestTags.HOME_FLING_LIST),
   ) {
     items(
       items = list,
       itemContent = { item ->
         VerticalFlingerListItem(item = item)
         ListItemDivider()
-      }
+      },
     )
   }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/customfling/VerticalFlingerListItem.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/customfling/VerticalFlingerListItem.kt
@@ -32,7 +32,7 @@ fun VerticalFlingerListItem(item: Item, modifier: Modifier = Modifier) {
       painter = painterResource(item.imageId),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Spacer(Modifier.height(16.dp))
     Text(text = item.title, style = typography.titleLarge)

--- a/app/src/main/java/com/guru/composecookbook/ui/home/dialogs/BottomSheetLayouts.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/dialogs/BottomSheetLayouts.kt
@@ -62,7 +62,7 @@ fun BottomSheetDrawer() {
       Box(modifier = Modifier.fillMaxSize()) {
         ScafoldContent(
           coroutineScope = coroutineScope,
-          showBottomSheet = { showBottomSheet.value = it }
+          showBottomSheet = { showBottomSheet.value = it },
         )
 
         if (showBottomSheet.value) {
@@ -75,7 +75,7 @@ fun BottomSheetDrawer() {
           }
         }
       }
-    }
+    },
   )
 }
 
@@ -84,7 +84,7 @@ private fun ScafoldContent(coroutineScope: CoroutineScope, showBottomSheet: (Boo
   Column(modifier = Modifier.fillMaxSize()) {
     Button(
       modifier = Modifier.fillMaxWidth().padding(16.dp).height(55.dp),
-      onClick = { showBottomSheet(true) }
+      onClick = { showBottomSheet(true) },
     ) {
       Text(text = "Show Bottom Sheet")
     }
@@ -102,14 +102,14 @@ fun FullBottomSheetContent(onClose: () -> Unit) {
     Column(
       modifier = Modifier.fillMaxSize().padding(top = 8.dp),
       verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       LottieLoadingView(
         context = LocalContext.current,
         file = "working.json",
-        modifier = Modifier.size(400.dp)
+        modifier = Modifier.size(400.dp),
       )
-      Button(onClick = { /*TODO*/}, modifier = Modifier.fillMaxWidth()) { Text(text = "Share Me") }
+      Button(onClick = { /*TODO*/ }, modifier = Modifier.fillMaxWidth()) { Text(text = "Share Me") }
       TextButton(onClick = { onClose.invoke() }) { Text("back") }
     }
   }
@@ -119,7 +119,7 @@ fun FullBottomSheetContent(onClose: () -> Unit) {
 fun DrawerContent() {
   Row(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Text(text = "Item 1")
     Icon(imageVector = Icons.Default.List, contentDescription = "List")
@@ -127,7 +127,7 @@ fun DrawerContent() {
 
   Row(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Text(text = "Item 2")
     Icon(imageVector = Icons.Default.List, contentDescription = "List")
@@ -135,7 +135,7 @@ fun DrawerContent() {
 
   Row(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Text(text = "Item 3")
     Icon(imageVector = Icons.Default.List, contentDescription = "List")
@@ -153,7 +153,7 @@ fun PlayerBottomSheet() {
       painter = painterResource(id = R.drawable.adele21),
       modifier = Modifier.size(65.dp),
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Text(
       text = "Someone Like you by Adele",
@@ -163,18 +163,18 @@ fun PlayerBottomSheet() {
     Icon(
       imageVector = Icons.Default.FavoriteBorder,
       modifier = Modifier.padding(8.dp),
-      contentDescription = null
+      contentDescription = null,
     )
     Icon(
       imageVector = Icons.Default.PlayArrow,
       modifier = Modifier.padding(8.dp),
-      contentDescription = null
+      contentDescription = null,
     )
   }
   Text(
     text = "Lyrics",
     style = MaterialTheme.typography.titleMedium,
-    modifier = Modifier.padding(16.dp)
+    modifier = Modifier.padding(16.dp),
   )
   Text(
     text =
@@ -188,6 +188,6 @@ fun PlayerBottomSheet() {
         "But I couldn't stay away, I couldn't fight it\n" +
         "I had hoped you'd see my face\n" +
         "And that you'd be reminded that for me, it isn't over",
-    modifier = Modifier.padding(16.dp)
+    modifier = Modifier.padding(16.dp),
   )
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/dialogs/DialogType.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/dialogs/DialogType.kt
@@ -8,5 +8,5 @@ enum class DialogType {
   LONGDIALOG,
   ROUNDED,
   DATEPICKER,
-  TIMEPICKER
+  TIMEPICKER,
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/dialogs/DialogsActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/dialogs/DialogsActivity.kt
@@ -65,6 +65,7 @@ class DialogsActivity : AppCompatActivity() {
 
   companion object {
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, isDarkTheme: Boolean) =
       Intent(context, DialogsActivity::class.java).apply { putExtra(DARK_THEME, isDarkTheme) }
   }
@@ -82,13 +83,13 @@ fun DialogScreen(onBack: () -> Unit) {
           IconButton(onClick = onBack) {
             Icon(
               imageVector = Icons.Default.ArrowBack,
-              contentDescription = stringResource(id = R.string.cd_back)
+              contentDescription = stringResource(id = R.string.cd_back),
             )
           }
-        }
+        },
       )
     },
-    content = { DialogsOptionList() }
+    content = { DialogsOptionList() },
   )
 }
 
@@ -108,51 +109,51 @@ fun DialogsOptionList() {
   Column(modifier = Modifier.verticalScroll(rememberScrollState()).padding(16.dp)) {
     Button(
       onClick = { dialogState = dialogState.copy(showDialog = true) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Plain Message Dialog")
     }
     Button(
       onClick = { dialogState = DialogState(true, DialogType.TITLE) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Title Dialog")
     }
     Button(
       onClick = { dialogState = DialogState(true, DialogType.VERTICALBUTTON) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Dialog with Vertical buttons")
     }
     Button(
       onClick = { dialogState = DialogState(true, DialogType.IMAGE) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Dialog with Image")
     }
     Button(
       onClick = { dialogState = DialogState(true, DialogType.LONGDIALOG) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Long Dialog")
     }
     Button(
       onClick = { dialogState = DialogState(true, DialogType.ROUNDED) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Extra Rounded Dialog")
     }
 
     Button(
       onClick = { dialogState = DialogState(true, DialogType.DATEPICKER) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Date Picker Dialog")
     }
 
     Button(
       onClick = { dialogState = DialogState(true, DialogType.TIMEPICKER) },
-      modifier = Modifier.fillMaxWidth().padding(16.dp)
+      modifier = Modifier.fillMaxWidth().padding(16.dp),
     ) {
       Text(text = "Time Picker Dialog")
     }
@@ -170,7 +171,7 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
         confirmButton = {
           TextButton(onClick = onDismiss, modifier = Modifier.padding(8.dp)) { Text(text = "Ok") }
         },
-        onDismissRequest = onDismiss
+        onDismissRequest = onDismiss,
       )
     DialogType.TITLE ->
       AlertDialog(
@@ -184,7 +185,7 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
             TextButton(onClick = onDismiss, modifier = Modifier.padding(4.dp)) { Text(text = "Ok") }
           }
         },
-        onDismissRequest = onDismiss
+        onDismissRequest = onDismiss,
       )
     DialogType.VERTICALBUTTON ->
       AlertDialog(
@@ -198,7 +199,7 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
             Text(text = "Ok")
           }
         },
-        onDismissRequest = onDismiss
+        onDismissRequest = onDismiss,
       )
     DialogType.IMAGE ->
       AlertDialog(
@@ -210,7 +211,7 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
         confirmButton = {
           TextButton(onClick = onDismiss, modifier = Modifier.padding(8.dp)) { Text(text = "Ok") }
         },
-        onDismissRequest = onDismiss
+        onDismissRequest = onDismiss,
       )
     DialogType.LONGDIALOG ->
       AlertDialog(
@@ -220,11 +221,11 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
             Text(item.subtitle, modifier = Modifier.padding(bottom = 8.dp))
             Image(
               painter = painterResource(DemoDataProvider.item.imageId),
-              contentDescription = null
+              contentDescription = null,
             )
             Text(
               item.subtitle + item.title + item.subtitle + item.title,
-              style = typography.subtitle2
+              style = typography.subtitle2,
             )
           }
         },
@@ -242,7 +243,7 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
             Image(
               painter = painterResource(DemoDataProvider.item.imageId),
               contentDescription = null,
-              modifier = Modifier.clip(RoundedCornerShape(16.dp))
+              modifier = Modifier.clip(RoundedCornerShape(16.dp)),
             )
           }
         },
@@ -250,7 +251,7 @@ fun ShowDialog(type: DialogType, onDismiss: () -> Unit) {
           TextButton(onClick = onDismiss, modifier = Modifier.padding(8.dp)) { Text(text = "Ok") }
         },
         onDismissRequest = onDismiss,
-        shape = RoundedCornerShape(16.dp)
+        shape = RoundedCornerShape(16.dp),
       )
     DialogType.DATEPICKER -> {
       val context = LocalContext.current

--- a/app/src/main/java/com/guru/composecookbook/ui/home/dynamic/DynamicUIActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/dynamic/DynamicUIActivity.kt
@@ -50,6 +50,7 @@ class DynamicUIActivity : ComponentActivity() {
   companion object {
     const val TYPE = "type"
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, dynamicUiType: String, isDarkTheme: Boolean) =
       Intent(context, DynamicUIActivity::class.java).apply {
         putExtra(TYPE, dynamicUiType)
@@ -69,23 +70,17 @@ fun DynamicUiWrapper(uiType: String, onback: () -> Unit) {
           IconButton(onClick = onback) {
             Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(id = R.string.cd_back))
           }
-        }
+        },
       )
     },
     content = { paddingValues ->
-      DynamicUiScreen(
-        uiType = uiType,
-        modifier = Modifier.padding(paddingValues),
-      )
-    }
+      DynamicUiScreen(uiType = uiType, modifier = Modifier.padding(paddingValues))
+    },
   )
 }
 
 @Composable
-fun DynamicUiScreen(
-  uiType: String,
-  modifier: Modifier = Modifier,
-) {
+fun DynamicUiScreen(uiType: String, modifier: Modifier = Modifier) {
   // We setup a base activity and we will change content depending upon ui type so
   // we don't have to create Activity for every feature showcase
   Box(modifier = modifier) {

--- a/app/src/main/java/com/guru/composecookbook/ui/home/dynamic/DynamicUiType.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/dynamic/DynamicUiType.kt
@@ -9,5 +9,5 @@ enum class DynamicUiType {
   MODIFIERS,
   ANDROIDVIEWS,
   PULLRERESH,
-  MOTIONLAYOUT
+  MOTIONLAYOUT,
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/dynamic/Modifiers.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/dynamic/Modifiers.kt
@@ -41,7 +41,7 @@ fun HowToModifiers() {
     Text(
       text = "Order in modifier values matters",
       style = typography.h6,
-      modifier = Modifier.padding(8.dp)
+      modifier = Modifier.padding(8.dp),
     )
     DemoText("No Modifiers")
     DemoElementButton(modifier = Modifier)

--- a/app/src/main/java/com/guru/composecookbook/ui/home/lists/GridListItem.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/lists/GridListItem.kt
@@ -33,27 +33,27 @@ fun GridListItem(item: Item, modifier: Modifier = Modifier) {
         .width(190.dp)
         .height(220.dp)
         .padding(8.dp)
-        .testTag("${TestTags.HOME_SCREEN_LIST_ITEM}-${item.id}")
+        .testTag("${TestTags.HOME_SCREEN_LIST_ITEM}-${item.id}"),
   ) {
     Column(modifier = Modifier.clickable(onClick = {})) {
       Image(
         painter = painterResource(item.imageId),
         contentScale = ContentScale.Crop,
         contentDescription = null,
-        modifier = Modifier.height(80.dp).fillMaxWidth()
+        modifier = Modifier.height(80.dp).fillMaxWidth(),
       )
       Column(modifier = Modifier.padding(8.dp)) {
         Text(
           text = item.title,
           style = MaterialTheme.typography.titleMedium.copy(fontSize = 14.sp),
           maxLines = 4,
-          overflow = TextOverflow.Ellipsis
+          overflow = TextOverflow.Ellipsis,
         )
         Text(
           text = item.subtitle,
           maxLines = 3,
           overflow = TextOverflow.Ellipsis,
-          style = MaterialTheme.typography.bodyMedium
+          style = MaterialTheme.typography.bodyMedium,
         )
         Text(text = item.source, style = MaterialTheme.typography.titleSmall)
       }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/lists/HorizontalListItem.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/lists/HorizontalListItem.kt
@@ -30,27 +30,27 @@ fun HorizontalListItem(item: Item, modifier: Modifier = Modifier) {
     shape = androidx.compose.material.MaterialTheme.shapes.medium,
     modifier =
       modifier.size(280.dp, 200.dp).testTag("${TestTags.HOME_SCREEN_LIST_ITEM}-${item.id}"),
-    elevation = 2.dp
+    elevation = 2.dp,
   ) {
     Column(modifier = Modifier.clickable(onClick = {})) {
       Image(
         painter = painterResource(id = item.imageId),
         contentScale = ContentScale.Crop,
         contentDescription = null,
-        modifier = Modifier.height(100.dp).fillMaxWidth()
+        modifier = Modifier.height(100.dp).fillMaxWidth(),
       )
       Column(modifier = Modifier.padding(16.dp)) {
         Text(
           text = item.title,
           style = MaterialTheme.typography.titleLarge,
           maxLines = 2,
-          overflow = TextOverflow.Ellipsis
+          overflow = TextOverflow.Ellipsis,
         )
         Text(
           text = item.subtitle,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
-          style = MaterialTheme.typography.bodyMedium
+          style = MaterialTheme.typography.bodyMedium,
         )
         Text(text = item.source, style = MaterialTheme.typography.titleSmall)
       }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/lists/ListViewActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/lists/ListViewActivity.kt
@@ -54,6 +54,7 @@ class ListViewActivity : ComponentActivity() {
   companion object {
     const val TYPE = "type"
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, listViewType: String, isDarkTheme: Boolean) =
       Intent(context, ListViewActivity::class.java).apply {
         putExtra(TYPE, listViewType)
@@ -78,34 +79,25 @@ fun ListViewContent(listType: String, onBack: () -> Unit) {
             Text(text = "ListView")
             Text(
               text = listType.lowercase(Locale.getDefault()),
-              style = MaterialTheme.typography.labelSmall
+              style = MaterialTheme.typography.labelSmall,
             )
           }
         },
         navigationIcon = {
           IconButton(onClick = onBack) {
-            Icon(
-              Icons.Filled.ArrowBack,
-              contentDescription = stringResource(id = R.string.cd_back),
-            )
+            Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(id = R.string.cd_back))
           }
         },
       )
     },
     content = { paddingValues ->
-      ListViewScreen(
-        listType = listType,
-        modifier = Modifier.padding(paddingValues),
-      )
-    }
+      ListViewScreen(listType = listType, modifier = Modifier.padding(paddingValues))
+    },
   )
 }
 
 @Composable
-fun ListViewScreen(
-  listType: String,
-  modifier: Modifier = Modifier,
-) {
+fun ListViewScreen(listType: String, modifier: Modifier = Modifier) {
   Box(modifier = modifier) {
     when (listType) {
       ListViewType.VERTICAL.name -> {
@@ -137,7 +129,7 @@ fun VerticalListView() {
           VerticalListItem(item = item)
         }
         ListItemDivider()
-      }
+      },
     )
   }
 }
@@ -150,19 +142,19 @@ fun HorizontalListView() {
     Text(
       modifier = Modifier.padding(16.dp),
       text = "Good Food",
-      style = MaterialTheme.typography.labelMedium
+      style = MaterialTheme.typography.labelMedium,
     )
     LazyRow(modifier = Modifier.padding(end = 16.dp)) {
       items(
         items = list,
-        itemContent = { HorizontalListItem(it, Modifier.padding(start = 16.dp, bottom = 16.dp)) }
+        itemContent = { HorizontalListItem(it, Modifier.padding(start = 16.dp, bottom = 16.dp)) },
       )
     }
     ListItemDivider()
     Text(
       modifier = Modifier.padding(16.dp),
       text = "Stories",
-      style = MaterialTheme.typography.labelMedium
+      style = MaterialTheme.typography.labelMedium,
     )
     StoryList(profiles = profiles, onProfileClicked = {})
   }
@@ -183,7 +175,7 @@ fun GridListView() {
           profileName = it.author,
           isMe = it.id == 1,
           modifier = Modifier.padding(start = 8.dp, end = 8.dp, top = 8.dp),
-          onClick = {}
+          onClick = {},
         )
       }
     }
@@ -194,17 +186,12 @@ fun GridListView() {
 private fun ListItemDivider() {
   Divider(
     modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
-    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
   )
 }
 
 @Preview(showBackground = true)
 @Composable
 fun DefaultPreview2() {
-  ComposeCookBookTheme {
-    ListViewContent(
-      ListViewType.VERTICAL.name,
-      onBack = {},
-    )
-  }
+  ComposeCookBookTheme { ListViewContent(ListViewType.VERTICAL.name, onBack = {}) }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/lists/ListViewType.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/lists/ListViewType.kt
@@ -4,5 +4,5 @@ enum class ListViewType(string: String) {
   VERTICAL("Vertical"),
   HORIZONTAL("Horizontal"),
   GRID("Grid"),
-  MIX("Vertical+Horizontal")
+  MIX("Vertical+Horizontal"),
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/lists/VerticalListItem.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/lists/VerticalListItem.kt
@@ -37,7 +37,7 @@ fun VerticalListItem(item: Item, modifier: Modifier = Modifier) {
       painter = painterResource(item.imageId),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Spacer(Modifier.height(16.dp))
     Text(text = item.title, style = typography.titleLarge)

--- a/app/src/main/java/com/guru/composecookbook/ui/home/lists/VerticalListItemSmall.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/lists/VerticalListItemSmall.kt
@@ -46,7 +46,7 @@ fun ItemImage(item: Item, modifier: Modifier = Modifier) {
     contentScale = ContentScale.Crop,
     contentDescription = null,
     modifier =
-      modifier.size(100.dp, 80.dp).clip(androidx.compose.material.MaterialTheme.shapes.medium)
+      modifier.size(100.dp, 80.dp).clip(androidx.compose.material.MaterialTheme.shapes.medium),
   )
 }
 
@@ -55,7 +55,7 @@ fun FavIcon(modifier: Modifier = Modifier) {
   val isFavourite = remember { mutableStateOf(true) }
   IconToggleButton(
     checked = isFavourite.value,
-    onCheckedChange = { isFavourite.value = !isFavourite.value }
+    onCheckedChange = { isFavourite.value = !isFavourite.value },
   ) {
     if (isFavourite.value) {
       Icon(imageVector = Icons.Filled.Favorite, contentDescription = null, modifier = modifier)
@@ -63,7 +63,7 @@ fun FavIcon(modifier: Modifier = Modifier) {
       Icon(
         imageVector = Icons.Default.FavoriteBorder,
         contentDescription = null,
-        modifier = modifier
+        modifier = modifier,
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/motionlayout/MotionLayoutDemo.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/motionlayout/MotionLayoutDemo.kt
@@ -93,7 +93,7 @@ private fun ButtonsMotionExample() {
             } """
     ),
     progress = buttonAnimationProgress,
-    modifier = Modifier.fillMaxWidth().wrapContentHeight()
+    modifier = Modifier.fillMaxWidth().wrapContentHeight(),
   ) {
     Button(onClick = { animateButton = !animateButton }, modifier = Modifier.layoutId("button1")) {
       Text(text = "Button1")
@@ -166,27 +166,27 @@ private fun ImageMotionExample() {
             } """
     ),
     progress = imageAnimationProgress,
-    modifier = Modifier.fillMaxSize()
+    modifier = Modifier.fillMaxSize(),
   ) {
     Image(
       painter = painterResource(id = albums[0].imageId),
       contentDescription = "",
-      modifier = Modifier.layoutId("image1").clickable { animateImage = !animateImage }
+      modifier = Modifier.layoutId("image1").clickable { animateImage = !animateImage },
     )
     Image(
       painter = painterResource(id = albums[1].imageId),
       contentDescription = "",
-      modifier = Modifier.layoutId("image2").clickable { animateImage = !animateImage }
+      modifier = Modifier.layoutId("image2").clickable { animateImage = !animateImage },
     )
     Image(
       painter = painterResource(id = albums[2].imageId),
       contentDescription = "",
-      modifier = Modifier.layoutId("image3").clickable { animateImage = !animateImage }
+      modifier = Modifier.layoutId("image3").clickable { animateImage = !animateImage },
     )
     Image(
       painter = painterResource(id = albums[3].imageId),
       contentDescription = "",
-      modifier = Modifier.layoutId("image4").clickable { animateImage = !animateImage }
+      modifier = Modifier.layoutId("image4").clickable { animateImage = !animateImage },
     )
   }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/tabslayout/TabLayout.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/tabslayout/TabLayout.kt
@@ -40,7 +40,7 @@ import kotlin.random.Random
 private enum class DemoTabs(val value: String) {
   APPLE("Apple"),
   GOOGLE("Google"),
-  AMAZON("Amazon")
+  AMAZON("Amazon"),
 }
 
 @Composable
@@ -57,7 +57,7 @@ fun TabLayout() {
     // Use ScrollableTabRow for list of tabs
     TabRow(
       selectedTabIndex = selectedIndex.value,
-      backgroundColor = MaterialTheme.colorScheme.surface
+      backgroundColor = MaterialTheme.colorScheme.surface,
     ) {
       tabsName.forEachIndexed { index, title ->
         Tab(
@@ -75,7 +75,7 @@ fun TabLayout() {
               }
             }
           },
-          text = { Text(title, color = MaterialTheme.colorScheme.onPrimaryContainer) }
+          text = { Text(title, color = MaterialTheme.colorScheme.onPrimaryContainer) },
         )
       }
     }
@@ -106,7 +106,7 @@ fun ScrollableListOfTabs() {
       edgePadding = 16.dp,
       indicator = noIndicator,
       backgroundColor = Color.Transparent,
-      modifier = Modifier.fillMaxWidth().padding(8.dp)
+      modifier = Modifier.fillMaxWidth().padding(8.dp),
     ) {
       tweets.forEachIndexed { index, tweet ->
         Tab(selected = index == selectedIndex.value, onClick = { selectedIndex.value = index }) {
@@ -114,7 +114,7 @@ fun ScrollableListOfTabs() {
             text = tweet.author,
             imageId = tweet.authorImageId,
             selected = index == selectedIndex.value,
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 16.dp)
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 16.dp),
           )
         }
       }
@@ -124,7 +124,7 @@ fun ScrollableListOfTabs() {
       isLiked = Random.nextBoolean(),
       onLikeClicked = {},
       onCommentsClicked = {},
-      onSendClicked = {}
+      onSendClicked = {},
     )
   }
 }
@@ -136,7 +136,7 @@ private fun CustomImageChip(
   text: String,
   imageId: Int,
   selected: Boolean,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Surface(
     color =
@@ -157,20 +157,20 @@ private fun CustomImageChip(
           when {
             selected -> MaterialTheme.colorScheme.primary
             else -> Color.LightGray
-          }
+          },
       ),
-    modifier = modifier
+    modifier = modifier,
   ) {
     Row(modifier = Modifier) {
       Image(
         painter = painterResource(imageId),
         contentDescription = null,
-        modifier = Modifier.padding(8.dp).size(20.dp).clip(CircleShape)
+        modifier = Modifier.padding(8.dp).size(20.dp).clip(CircleShape),
       )
       Text(
         text = text,
         style = MaterialTheme.typography.labelMedium,
-        modifier = Modifier.padding(end = 8.dp, top = 8.dp, bottom = 8.dp)
+        modifier = Modifier.padding(end = 8.dp, top = 8.dp, bottom = 8.dp),
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/timer/TimerDemo.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/timer/TimerDemo.kt
@@ -35,7 +35,7 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
     Column(
       modifier = Modifier.fillMaxWidth().fillMaxHeight().padding(16.dp),
       verticalArrangement = Arrangement.Center,
-      horizontalAlignment = Alignment.CenterHorizontally
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
       TimerType.values().forEach {
         TimerView(
@@ -45,13 +45,13 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
             Modifier.border(
                 width = 1.dp,
                 color = MaterialTheme.colorScheme.onSurface,
-                shape = RoundedCornerShape(4.dp)
+                shape = RoundedCornerShape(4.dp),
               )
               .padding(horizontal = 8.dp, vertical = 4.dp),
           componentModifier =
             Modifier.background(
                 color = MaterialTheme.colorScheme.onSurface,
-                shape = RoundedCornerShape(4.dp)
+                shape = RoundedCornerShape(4.dp),
               )
               .padding(horizontal = 4.dp, vertical = 4.dp),
           digitStyle = typography.body1.copy(color = MaterialTheme.colorScheme.onPrimary),
@@ -59,8 +59,8 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
           separatorStyle =
             typography.body1.copy(
               color = MaterialTheme.colorScheme.onSurface,
-              fontWeight = FontWeight.Bold
-            )
+              fontWeight = FontWeight.Bold,
+            ),
         )
         Spacer(modifier = Modifier.height(12.dp))
       }
@@ -73,7 +73,7 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
         backgroundColor = Color.Black,
         textColor = Color.White,
         icon = painterResource(id = R.drawable.ic_baseline_access_time_24),
-        iconColor = ColorFilter.tint(color = Color.White)
+        iconColor = ColorFilter.tint(color = Color.White),
       )
       Spacer(modifier = Modifier.height(12.dp))
 
@@ -83,7 +83,7 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
         backgroundColor = Color.Black,
         textColor = Color.White,
         icon = painterResource(id = R.drawable.ic_baseline_access_time_24),
-        iconColor = ColorFilter.tint(color = Color.White)
+        iconColor = ColorFilter.tint(color = Color.White),
       )
       Spacer(modifier = Modifier.height(12.dp))
 
@@ -93,7 +93,7 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
         backgroundColor = Color.Black,
         textColor = Color.White,
         icon = painterResource(id = R.drawable.ic_baseline_access_time_24),
-        iconColor = ColorFilter.tint(color = Color.White)
+        iconColor = ColorFilter.tint(color = Color.White),
       )
       Spacer(modifier = Modifier.height(12.dp))
 
@@ -103,7 +103,7 @@ fun TimerDemo(timerViewModel: TimerViewModel = viewModel()) {
         backgroundColor = Color.Black,
         textColor = Color.White,
         icon = painterResource(id = R.drawable.ic_baseline_access_time_24),
-        iconColor = ColorFilter.tint(color = Color.White)
+        iconColor = ColorFilter.tint(color = Color.White),
       )
       Spacer(modifier = Modifier.height(12.dp))
     }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/timer/TimerView.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/timer/TimerView.kt
@@ -115,6 +115,6 @@ fun TimerViewPreview() {
         .padding(horizontal = 4.dp, vertical = 4.dp),
     digitStyle = typography.body1.copy(color = orange700),
     separatorModifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
-    separatorStyle = typography.body1.copy(color = teal200)
+    separatorStyle = typography.body1.copy(color = teal200),
   )
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/home/timer/TimerViewAnimation.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/home/timer/TimerViewAnimation.kt
@@ -38,7 +38,7 @@ enum class TimerAnimation {
   SLIDE_TOP,
   SLIDE_BOTTOM,
   BOUNCE_TOP,
-  BOUNCE_BOTTOM
+  BOUNCE_BOTTOM,
 }
 
 @ExperimentalAnimationApi
@@ -57,7 +57,7 @@ fun TimerViewAnimation(
   timeDurationSlide: Int = 500,
   timeSpace: String = " : ",
   icon: Painter? = null,
-  iconColor: ColorFilter? = null
+  iconColor: ColorFilter? = null,
 ) {
   Card(
     backgroundColor = backgroundColor,
@@ -69,14 +69,14 @@ fun TimerViewAnimation(
       modifier =
         Modifier.padding(start = 8.dp, end = 8.dp).padding(all = backgroundPadding).alpha(0f),
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.Center
+      horizontalArrangement = Arrangement.Center,
     ) {
       icon?.let {
         Image(
           modifier = Modifier.padding(end = 4.dp),
           painter = it,
           colorFilter = iconColor ?: ColorFilter.tint(textColor),
-          contentDescription = null
+          contentDescription = null,
         )
       }
 
@@ -86,21 +86,21 @@ fun TimerViewAnimation(
         textAlign = TextAlign.Center,
         color = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
     }
 
     Row(
       modifier = Modifier.padding(start = 8.dp, end = 8.dp).padding(all = backgroundPadding),
       verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.Center
+      horizontalArrangement = Arrangement.Center,
     ) {
       icon?.let {
         Image(
           modifier = Modifier.padding(end = 4.dp),
           painter = it,
           colorFilter = iconColor ?: ColorFilter.tint(textColor),
-          contentDescription = null
+          contentDescription = null,
         )
       }
 
@@ -111,7 +111,7 @@ fun TimerViewAnimation(
         timeDurationSlide = timeDurationSlide,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewAnimationContent(
@@ -121,7 +121,7 @@ fun TimerViewAnimation(
         timeDurationSlide = timeDurationSlide,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewSeparator(
@@ -129,7 +129,7 @@ fun TimerViewAnimation(
         textStyle = textStyle,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewAnimationContent(
@@ -139,7 +139,7 @@ fun TimerViewAnimation(
         timeDurationSlide = timeDurationSlide,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewAnimationContent(
@@ -149,7 +149,7 @@ fun TimerViewAnimation(
         timeDurationSlide = timeDurationSlide,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewSeparator(
@@ -157,7 +157,7 @@ fun TimerViewAnimation(
         textStyle = textStyle,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewAnimationContent(
@@ -167,7 +167,7 @@ fun TimerViewAnimation(
         timeDurationSlide = timeDurationSlide,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
 
       TimeViewAnimationContent(
@@ -177,7 +177,7 @@ fun TimerViewAnimation(
         timeDurationSlide = timeDurationSlide,
         textColor = textColor,
         fontFamily = fontFamily,
-        fontWeight = fontWeight
+        fontWeight = fontWeight,
       )
     }
   }
@@ -220,14 +220,14 @@ fun TimeViewAnimationContent(
   timerAnimation: TimerAnimation,
   timeDurationSlide: Int,
   fontFamily: FontFamily,
-  fontWeight: FontWeight
+  fontWeight: FontWeight,
 ) {
   AnimatedContent(
     targetState = timeContent,
     transitionSpec = {
       addAnimation(timeDurationSlide = timeDurationSlide, timeAnimation = timerAnimation)
         .using(SizeTransform(clip = true))
-    }
+    },
   ) { targetCount ->
     Text(
       text = targetCount,
@@ -235,7 +235,7 @@ fun TimeViewAnimationContent(
       textAlign = TextAlign.Center,
       color = textColor,
       fontFamily = fontFamily,
-      fontWeight = fontWeight
+      fontWeight = fontWeight,
     )
   }
 }
@@ -247,7 +247,7 @@ fun TimeViewSeparator(
   textStyle: TextStyle,
   textColor: Color,
   fontFamily: FontFamily,
-  fontWeight: FontWeight
+  fontWeight: FontWeight,
 ) {
   Text(
     text = timeSpace,
@@ -255,6 +255,6 @@ fun TimeViewSeparator(
     textAlign = TextAlign.Center,
     color = textColor,
     fontFamily = fontFamily,
-    fontWeight = fontWeight
+    fontWeight = fontWeight,
   )
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/AllButtons.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/AllButtons.kt
@@ -57,7 +57,7 @@ fun AllButtons() {
     Button(
       onClick = {},
       modifier = Modifier.padding(8.dp),
-      elevation = ButtonDefaults.buttonElevation()
+      elevation = ButtonDefaults.buttonElevation(),
     ) {
       Text(text = "Flat")
     }
@@ -72,7 +72,7 @@ fun AllButtons() {
         Icon(
           imageVector = Icons.Default.FavoriteBorder,
           contentDescription = null,
-          modifier = Modifier.padding(end = 4.dp)
+          modifier = Modifier.padding(end = 4.dp),
         )
         Text(text = "Icon Button")
       }
@@ -82,19 +82,16 @@ fun AllButtons() {
       Icon(
         imageVector = Icons.Default.FavoriteBorder,
         contentDescription = null,
-        modifier = Modifier.padding(start = 4.dp)
+        modifier = Modifier.padding(start = 4.dp),
       )
     }
   }
   // custom background buttons
-  val outlineButtonColor =
-    ButtonDefaults.outlinedButtonColors(
-      contentColor = purple200,
-    )
+  val outlineButtonColor = ButtonDefaults.outlinedButtonColors(contentColor = purple200)
   val mainButtonColor =
     ButtonDefaults.buttonColors(
       containerColor = purple,
-      contentColor = MaterialTheme.colorScheme.surface
+      contentColor = MaterialTheme.colorScheme.surface,
     )
   Row {
     OutlinedButton(colors = outlineButtonColor, onClick = {}, modifier = Modifier.padding(8.dp)) {
@@ -110,14 +107,14 @@ fun AllButtons() {
         colors =
           listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.inversePrimary),
         0f,
-        250f
+        250f,
       )
     val verticalGradient =
       Brush.verticalGradient(
         colors =
           listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.inversePrimary),
         startY = 0f,
-        endY = 100f
+        endY = 100f,
       )
     Text(
       text = "Horizontal gradient",
@@ -127,7 +124,7 @@ fun AllButtons() {
           .clickable(onClick = {})
           .clip(RoundedCornerShape(4.dp))
           .background(brush = horizontalGradient)
-          .padding(12.dp)
+          .padding(12.dp),
     )
     Text(
       text = "Vertical gradient",
@@ -137,7 +134,7 @@ fun AllButtons() {
           .clickable(onClick = {})
           .clip(RoundedCornerShape(4.dp))
           .background(brush = verticalGradient)
-          .padding(12.dp)
+          .padding(12.dp),
     )
   }
 
@@ -164,7 +161,7 @@ fun AllButtons() {
     iconPadding = PaddingValues(4.dp),
     swipeButtonState = SwipeButtonState.INITIAL,
     shape = CircleShape,
-    enabled = false
+    enabled = false,
   ) {
     Text(text = "Swipe", style = typography.body1)
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/AppBars.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/AppBars.kt
@@ -63,10 +63,10 @@ fun TopAppBarsDemo() {
       IconButton(onClick = {}) {
         Icon(
           imageVector = Icons.Default.ArrowBack,
-          contentDescription = stringResource(id = R.string.cd_back)
+          contentDescription = stringResource(id = R.string.cd_back),
         )
       }
-    }
+    },
   )
 
   Spacer(modifier = Modifier.height(8.dp))
@@ -80,7 +80,7 @@ fun TopAppBarsDemo() {
       IconButton(onClick = {}) {
         Icon(
           painter = painterResource(id = com.guru.composecookbook.data.R.drawable.ic_instagram),
-          contentDescription = null
+          contentDescription = null,
         )
       }
     },
@@ -88,10 +88,10 @@ fun TopAppBarsDemo() {
       IconButton(onClick = {}) {
         Icon(
           painter = painterResource(id = com.guru.composecookbook.data.R.drawable.ic_send),
-          contentDescription = null
+          contentDescription = null,
         )
       }
-    }
+    },
   )
 
   Spacer(modifier = Modifier.height(8.dp))
@@ -102,7 +102,7 @@ fun TopAppBarsDemo() {
         painter = painterResource(id = com.guru.composecookbook.theme.R.drawable.ic_twitter),
         contentDescription = null,
         tint = twitterColor,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
       )
     },
     backgroundColor = MaterialTheme.colorScheme.surface,
@@ -113,16 +113,16 @@ fun TopAppBarsDemo() {
         painter = painterResource(id = com.guru.composecookbook.data.R.drawable.p6),
         contentDescription = null,
         modifier =
-          Modifier.padding(vertical = 4.dp, horizontal = 8.dp).size(32.dp).clip(CircleShape)
+          Modifier.padding(vertical = 4.dp, horizontal = 8.dp).size(32.dp).clip(CircleShape),
       )
     },
     actions = {
       Icon(
         imageVector = Icons.Default.StarBorder,
         contentDescription = null,
-        modifier = Modifier.padding(horizontal = 8.dp)
+        modifier = Modifier.padding(horizontal = 8.dp),
       )
-    }
+    },
   )
   Spacer(modifier = Modifier.height(8.dp))
 }
@@ -164,7 +164,7 @@ fun NavigationBarDemo() {
         Text(
           text = stringResource(id = com.guru.composecookbook.spotify.R.string.spotify_nav_search)
         )
-      }
+      },
     )
     BottomNavigationItem(
       icon = { Icon(imageVector = Icons.Outlined.LibraryMusic, contentDescription = null) },
@@ -174,7 +174,7 @@ fun NavigationBarDemo() {
         Text(
           text = stringResource(id = com.guru.composecookbook.spotify.R.string.spotify_nav_library)
         )
-      }
+      },
     )
   }
 

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/BadgeExamples.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/BadgeExamples.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 fun BadgeExamples() {
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(16.dp)
+    verticalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     // Simple Badge
     BadgedBox(badge = { Badge { Text("8") } }) {
@@ -44,7 +44,7 @@ fun BadgeExamples() {
         },
         label = { Text("Notifications") },
         selected = true,
-        onClick = {}
+        onClick = {},
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/BottomSheetExamples.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/BottomSheetExamples.kt
@@ -15,7 +15,7 @@ fun BottomSheetExamples() {
 
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp)
+    verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     // Modal Bottom Sheet
     Button(onClick = { showModalBottomSheet = true }) { Text("Show Modal Bottom Sheet") }
@@ -23,23 +23,23 @@ fun BottomSheetExamples() {
     if (showModalBottomSheet) {
       ModalBottomSheet(
         onDismissRequest = { showModalBottomSheet = false },
-        dragHandle = { BottomSheetDefaults.DragHandle() }
+        dragHandle = { BottomSheetDefaults.DragHandle() },
       ) {
         Column(
           modifier = Modifier.fillMaxWidth().padding(16.dp),
-          verticalArrangement = Arrangement.spacedBy(16.dp)
+          verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
           ListItem(
             headlineContent = { Text("Share") },
-            leadingContent = { Icon(Icons.Default.Share, contentDescription = null) }
+            leadingContent = { Icon(Icons.Default.Share, contentDescription = null) },
           )
           ListItem(
             headlineContent = { Text("Copy link") },
-            leadingContent = { Icon(Icons.Default.Share, contentDescription = null) }
+            leadingContent = { Icon(Icons.Default.Share, contentDescription = null) },
           )
           ListItem(
             headlineContent = { Text("Edit") },
-            leadingContent = { Icon(Icons.Default.Share, contentDescription = null) }
+            leadingContent = { Icon(Icons.Default.Share, contentDescription = null) },
           )
         }
       }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Chips.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Chips.kt
@@ -34,13 +34,13 @@ fun Chips() {
     CustomImageChip(
       text = "custom",
       imageId = com.guru.composecookbook.data.R.drawable.p2,
-      selected = true
+      selected = true,
     )
     Spacer(modifier = Modifier.padding(8.dp))
     CustomImageChip(
       text = "custom2",
       imageId = com.guru.composecookbook.data.R.drawable.p6,
-      selected = false
+      selected = false,
     )
   }
   SubtitleText(subtitle = "Buttons with circle clipping.")
@@ -61,7 +61,7 @@ private fun CustomImageChip(
   text: String,
   imageId: Int,
   selected: Boolean,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Surface(
     color =
@@ -82,20 +82,20 @@ private fun CustomImageChip(
           when {
             selected -> MaterialTheme.colorScheme.primary
             else -> Color.LightGray
-          }
+          },
       ),
-    modifier = modifier
+    modifier = modifier,
   ) {
     Row(modifier = Modifier) {
       Image(
         painter = painterResource(imageId),
         contentDescription = null,
-        modifier = Modifier.padding(8.dp).size(20.dp).clip(CircleShape)
+        modifier = Modifier.padding(8.dp).size(20.dp).clip(CircleShape),
       )
       Text(
         text = text,
         style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.padding(end = 8.dp, top = 8.dp, bottom = 8.dp)
+        modifier = Modifier.padding(end = 8.dp, top = 8.dp, bottom = 8.dp),
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/DialogExamples.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/DialogExamples.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 fun DialogExamples() {
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp)
+    verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     var showBasicDialog by remember { mutableStateOf(false) }
     var showConfirmationDialog by remember { mutableStateOf(false) }
@@ -30,7 +30,7 @@ fun DialogExamples() {
           Surface(
             modifier = Modifier.wrapContentWidth().wrapContentHeight(),
             shape = MaterialTheme.shapes.large,
-            tonalElevation = 6.dp
+            tonalElevation = 6.dp,
           ) {
             Column(modifier = Modifier.padding(16.dp)) {
               Text(text = "Basic Dialog", style = MaterialTheme.typography.headlineSmall)
@@ -39,13 +39,13 @@ fun DialogExamples() {
               Spacer(modifier = Modifier.height(24.dp))
               TextButton(
                 onClick = { showBasicDialog = false },
-                modifier = Modifier.align(Alignment.End)
+                modifier = Modifier.align(Alignment.End),
               ) {
                 Text("Dismiss")
               }
             }
           }
-        }
+        },
       )
     }
 
@@ -62,7 +62,7 @@ fun DialogExamples() {
         },
         dismissButton = {
           TextButton(onClick = { showConfirmationDialog = false }) { Text("Cancel") }
-        }
+        },
       )
     }
 
@@ -75,7 +75,7 @@ fun DialogExamples() {
         icon = { Icon(Icons.Default.Add, contentDescription = null) },
         title = { Text("Alert") },
         text = { Text("This is an important alert message.") },
-        confirmButton = { TextButton(onClick = { showAlertDialog = false }) { Text("OK") } }
+        confirmButton = { TextButton(onClick = { showAlertDialog = false }) { Text("OK") } },
       )
     }
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Layouts.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Layouts.kt
@@ -45,55 +45,55 @@ fun TypesOfRows() {
   Text(text = "Arrangement.Start ", style = typography.caption, modifier = Modifier.padding(8.dp))
   Row(
     horizontalArrangement = Arrangement.Start,
-    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_START)
+    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_START),
   ) {
     MultipleTexts()
   }
   Text(text = "Arrangement.End ", style = typography.caption, modifier = Modifier.padding(8.dp))
   Row(
     horizontalArrangement = Arrangement.End,
-    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_END)
+    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_END),
   ) {
     MultipleTexts()
   }
   Text(text = "Arrangement.Center ", style = typography.caption, modifier = Modifier.padding(8.dp))
   Row(
     horizontalArrangement = Arrangement.Center,
-    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_CENTER)
+    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_CENTER),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.SpaceAround ",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Row(
     horizontalArrangement = Arrangement.SpaceAround,
-    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_SPACE_AROUND)
+    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_SPACE_AROUND),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.SpaceBetween ",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Row(
     horizontalArrangement = Arrangement.SpaceBetween,
     modifier =
-      Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_SPACE_BETWEEN)
+      Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_SPACE_BETWEEN),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.SpaceEvenly ",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Row(
     horizontalArrangement = Arrangement.SpaceEvenly,
-    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_SPACE_EVENLY)
+    modifier = Modifier.padding(8.dp).fillMaxWidth().testTag(TestTags.HOME_LAYOUTS_ROW_SPACE_EVENLY),
   ) {
     MultipleTexts()
   }
@@ -110,59 +110,59 @@ fun TypeOfColumns() {
   Text(text = "Arrangement.Top", style = typography.caption, modifier = Modifier.padding(8.dp))
   Column(
     verticalArrangement = Arrangement.Top,
-    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_TOP)
+    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_TOP),
   ) {
     MultipleTexts()
   }
   Text(text = "Arrangement.Bottom", style = typography.caption, modifier = Modifier.padding(8.dp))
   Column(
     verticalArrangement = Arrangement.Bottom,
-    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_BOTTOM)
+    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_BOTTOM),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.Center + Alignment.CenterHorizontally",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Column(
     verticalArrangement = Arrangement.Center,
     horizontalAlignment = Alignment.CenterHorizontally,
-    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_CENTER)
+    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_CENTER),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.SpaceAround",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Column(
     verticalArrangement = Arrangement.SpaceAround,
-    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_SPACE_AROUND)
+    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_SPACE_AROUND),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.SpaceEvenly",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Column(
     verticalArrangement = Arrangement.SpaceEvenly,
-    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_SPACE_EVENLY)
+    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_SPACE_EVENLY),
   ) {
     MultipleTexts()
   }
   Text(
     text = "Arrangement.SpaceBetween",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Column(
     verticalArrangement = Arrangement.SpaceBetween,
-    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_SPACE_BETWEEN)
+    modifier = columnModifier.testTag(TestTags.HOME_LAYOUTS_COLUMN_SPACE_BETWEEN),
   ) {
     MultipleTexts()
   }
@@ -179,7 +179,7 @@ fun TypeOfBoxs() {
   Text(
     text = "Children with no align",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Box(modifier = boxModifier.testTag(TestTags.HOME_LAYOUTS_BOX_NO_ALIGN)) {
     Material3Card(backgroundColor = green700, elevation = 4.dp, modifier = Modifier.size(200.dp)) {}
@@ -189,23 +189,23 @@ fun TypeOfBoxs() {
   Text(
     text = "Children with Topstart, center & bottomEnd align",
     style = typography.caption,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Box(modifier = boxModifier.testTag(TestTags.HOME_LAYOUTS_BOX_TOP_CENTER_AND_NO_ALIGN)) {
     Material3Card(
       backgroundColor = green700,
       elevation = 4.dp,
-      modifier = Modifier.size(200.dp).align(Alignment.TopStart)
+      modifier = Modifier.size(200.dp).align(Alignment.TopStart),
     ) {}
     Material3Card(
       backgroundColor = green500,
       elevation = 4.dp,
-      modifier = Modifier.size(150.dp).align(Alignment.Center)
+      modifier = Modifier.size(150.dp).align(Alignment.Center),
     ) {}
     Material3Card(
       backgroundColor = green200,
       elevation = 4.dp,
-      modifier = Modifier.size(100.dp).align(Alignment.BottomEnd)
+      modifier = Modifier.size(100.dp).align(Alignment.BottomEnd),
     ) {}
   }
 }
@@ -226,7 +226,7 @@ fun ConstraintLayouts() {
 
     Button(
       onClick = {},
-      modifier = Modifier.constrainAs(mainButton) { top.linkTo(parent.top, margin = 16.dp) }
+      modifier = Modifier.constrainAs(mainButton) { top.linkTo(parent.top, margin = 16.dp) },
     ) {
       Text("Main button")
     }
@@ -236,23 +236,23 @@ fun ConstraintLayouts() {
       Modifier.constrainAs(mainText) {
         top.linkTo(parent.top, margin = 16.dp)
         absoluteLeft.linkTo(mainButton.end, margin = 16.dp)
-      }
+      },
     )
     Text(
       "Secondary Text",
       Modifier.constrainAs(seconderyText) {
         top.linkTo(mainText.bottom, margin = 16.dp)
         absoluteLeft.linkTo(mainButton.end, margin = 16.dp)
-      }
+      },
     )
 
     OutlinedButton(
-      onClick = { /* Do something */},
+      onClick = { /* Do something */ },
       modifier =
         Modifier.constrainAs(outlineButton) {
           top.linkTo(seconderyText.bottom, margin = 16.dp)
           start.linkTo(seconderyText.end, margin = 16.dp)
-        }
+        },
     ) {
       Text("Outline Button")
     }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/ListItems.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/ListItems.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.unit.dp
 fun ListItems() {
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp)
+    verticalArrangement = Arrangement.spacedBy(8.dp),
   ) {
     // One-line list item
     ListItem(
       headlineContent = { Text("One-line list item") },
-      leadingContent = { Icon(Icons.Default.Star, contentDescription = null) }
+      leadingContent = { Icon(Icons.Default.Star, contentDescription = null) },
     )
 
     Divider()
@@ -30,7 +30,7 @@ fun ListItems() {
       headlineContent = { Text("Two-line list item") },
       supportingContent = { Text("Secondary text") },
       leadingContent = { Icon(Icons.Default.Favorite, contentDescription = null) },
-      trailingContent = { Text("meta") }
+      trailingContent = { Text("meta") },
     )
 
     Divider()
@@ -41,7 +41,7 @@ fun ListItems() {
       overlineContent = { Text("OVERLINE") },
       supportingContent = { Text("Secondary text\nThird line of text") },
       leadingContent = { Icon(Icons.Default.AccountCircle, contentDescription = null) },
-      trailingContent = { Switch(checked = true, onCheckedChange = {}) }
+      trailingContent = { Switch(checked = true, onCheckedChange = {}) },
     )
   }
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Loaders.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Loaders.kt
@@ -25,7 +25,7 @@ fun Loaders() {
 
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     LinearProgressIndicator()
     Text(text = "Loading with text...", modifier = Modifier.padding(8.dp))

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/NavigationRailExample.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/NavigationRailExample.kt
@@ -23,14 +23,14 @@ fun NavigationRailExample() {
         FloatingActionButton(onClick = {}, modifier = Modifier.padding(vertical = 8.dp)) {
           Icon(Icons.Default.Add, contentDescription = "Add")
         }
-      }
+      },
     ) {
       items.forEachIndexed { index, item ->
         NavigationRailItem(
           selected = selectedItem == index,
           onClick = { selectedItem = index },
           icon = { Icon(icons[index], contentDescription = item) },
-          label = { Text(item) }
+          label = { Text(item) },
         )
       }
     }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/SearchBars.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/SearchBars.kt
@@ -23,7 +23,7 @@ fun SearchBars() {
 
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(16.dp)
+    verticalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     // Simple SearchBar with modified layout
     Box(modifier = Modifier.fillMaxWidth()) {
@@ -41,7 +41,7 @@ fun SearchBars() {
           if (!active) searchText = ""
         },
         placeholder = { Text("Search") },
-        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) }
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
       ) {
         LazyColumn(modifier = Modifier.fillMaxWidth().heightIn(max = 300.dp)) {
           items(3) { idx ->
@@ -52,7 +52,7 @@ fun SearchBars() {
                 Modifier.clickable {
                   searchText = "Recent search $idx"
                   searchActive = false
-                }
+                },
             )
           }
         }
@@ -75,7 +75,7 @@ fun SearchBars() {
           if (!active) dockedText = ""
         },
         placeholder = { Text("Docked Search") },
-        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) }
+        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
       ) {
         Surface(modifier = Modifier.fillMaxWidth().heightIn(max = 350.dp)) {
           LazyColumn {
@@ -87,7 +87,7 @@ fun SearchBars() {
                   Modifier.clickable {
                     dockedText = "Suggestion $idx"
                     dockedActive = false
-                  }
+                  },
               )
             }
           }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/SegmentedButtons.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/SegmentedButtons.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 fun SegmentedButtons() {
   Column(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(16.dp)
+    verticalArrangement = Arrangement.spacedBy(16.dp),
   ) {
     var selectedOption by remember { mutableStateOf(0) }
     val options = listOf("Option 1", "Option 2", "Option 3")
@@ -28,7 +28,7 @@ fun SegmentedButtons() {
           leadingIcon =
             if (selectedOption == index) {
               { Icon(Icons.Default.Done, contentDescription = null) }
-            } else null
+            } else null,
         )
       }
     }
@@ -41,7 +41,7 @@ fun SegmentedButtons() {
           selected = selectedIconOption == index,
           onClick = { selectedIconOption = index },
           label = {},
-          leadingIcon = { Icon(Icons.Default.Android, contentDescription = null) }
+          leadingIcon = { Icon(Icons.Default.Android, contentDescription = null) },
         )
       }
     }
@@ -54,10 +54,7 @@ fun SegmentedButtons() {
           selected = selected == option,
           onClick = { selected = option },
           shape =
-            SegmentedButtonDefaults.itemShape(
-              index = options.indexOf(option),
-              count = options.size
-            ),
+            SegmentedButtonDefaults.itemShape(index = options.indexOf(option), count = options.size),
         ) {
           Text(option)
         }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Snackbars.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Snackbars.kt
@@ -17,14 +17,14 @@ fun SnackBars() {
   Snackbar(modifier = Modifier.padding(4.dp)) { Text(text = "This is a basic snackbar") }
   Snackbar(
     modifier = Modifier.padding(4.dp),
-    action = { TextButton(onClick = {}) { Text(text = "Remove") } }
+    action = { TextButton(onClick = {}) { Text(text = "Remove") } },
   ) {
     Text(text = "This is a basic Snackbar with action item")
   }
   Snackbar(
     modifier = Modifier.padding(4.dp),
     actionOnNewLine = true,
-    action = { TextButton(onClick = {}) { Text(text = "Remove") } }
+    action = { TextButton(onClick = {}) { Text(text = "Remove") } },
   ) {
     Text(text = "Snackbar with action item below text")
   }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/SwipeButton.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/SwipeButton.kt
@@ -47,7 +47,7 @@ fun SwipeButton(
   icon: ImageVector = Icons.Default.ArrowForward,
   rotateIcon: Boolean = true,
   iconPadding: PaddingValues = PaddingValues(2.dp),
-  content: @Composable RowScope.() -> Unit
+  content: @Composable RowScope.() -> Unit,
 ) {
   val containerColor = colors.containerColor
   val dragOffset = remember { mutableStateOf(0f) }
@@ -65,7 +65,7 @@ fun SwipeButton(
   ) {
     BoxWithConstraints(
       modifier = Modifier.fillMaxSize(),
-      contentAlignment = Alignment.CenterStart
+      contentAlignment = Alignment.CenterStart,
     ) {
       // Content
       val maxWidth = this.constraints.maxWidth.toFloat()
@@ -83,12 +83,12 @@ fun SwipeButton(
                 .padding(iconPadding)
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.onPrimary)
-                .align(Alignment.Center)
+                .align(Alignment.Center),
           ) {
             Icon(
               imageVector = Icons.Default.Done,
               contentDescription = "Done",
-              tint = MaterialTheme.colorScheme.primary
+              tint = MaterialTheme.colorScheme.primary,
             )
           }
         }
@@ -103,7 +103,7 @@ fun SwipeButton(
                 Modifier.fillMaxSize().padding(contentPadding),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically,
-                content = content
+                content = content,
               )
             }
           }
@@ -133,9 +133,9 @@ fun SwipeButton(
                   } else {
                     dragOffset.value = 0f
                   }
-                }
+                },
               )
-              .background(MaterialTheme.colorScheme.onPrimary, shape = CircleShape)
+              .background(MaterialTheme.colorScheme.onPrimary, shape = CircleShape),
         ) {
           Icon(
             imageVector = icon,
@@ -157,5 +157,5 @@ fun SwipeButton(
 enum class SwipeButtonState {
   INITIAL,
   SWIPED,
-  COLLAPSED
+  COLLAPSED,
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/TextInputs.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/TextInputs.kt
@@ -52,7 +52,7 @@ fun TextInputs() {
     placeholder = { Text(text = "12334444") },
     visualTransformation = PasswordVisualTransformation(),
     onValueChange = { text = it },
-    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
   )
 
   OutlinedTextField(
@@ -62,7 +62,7 @@ fun TextInputs() {
     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
     label = { Text(text = "Email address") },
     placeholder = { Text(text = "Your email") },
-    onValueChange = { text = it }
+    onValueChange = { text = it },
   )
   OutlinedTextField(
     value = text,
@@ -72,7 +72,7 @@ fun TextInputs() {
     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
     label = { Text(text = "Email address") },
     placeholder = { Text(text = "Your email") },
-    onValueChange = { text = it }
+    onValueChange = { text = it },
   )
 
   var numberText by remember { mutableStateOf(TextFieldValue("")) }
@@ -82,7 +82,7 @@ fun TextInputs() {
     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
     label = { Text(text = "Phone number") },
     placeholder = { Text(text = "88888888") },
-    onValueChange = { numberText = it }
+    onValueChange = { numberText = it },
   )
 }
 

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Texts.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Texts.kt
@@ -26,7 +26,7 @@ fun TextDemo() {
     Text(
       text = "Medium Bold",
       style = typography.body1.copy(fontWeight = FontWeight.Medium),
-      modifier = textModifier
+      modifier = textModifier,
     )
     Text(text = "Bold", style = typography.body1.copy(fontWeight = FontWeight.Bold))
     Text(text = "Extra Bold", style = typography.body1.copy(fontWeight = FontWeight.Bold))
@@ -38,17 +38,17 @@ fun TextDemo() {
     Text(
       text = "Cursive",
       style = typography.body1.copy(fontFamily = FontFamily.Cursive),
-      modifier = textModifier
+      modifier = textModifier,
     )
     Text(
       text = "SansSerif",
       style = typography.body1.copy(fontFamily = FontFamily.SansSerif),
-      modifier = textModifier
+      modifier = textModifier,
     )
     Text(
       text = "Monospace",
       style = typography.body1.copy(fontFamily = FontFamily.Monospace),
-      modifier = textModifier
+      modifier = textModifier,
     )
   }
 
@@ -61,7 +61,7 @@ fun TextDemo() {
       text = "Monospace",
       textDecoration =
         TextDecoration.combine(listOf(TextDecoration.Underline, TextDecoration.LineThrough)),
-      modifier = textModifier
+      modifier = textModifier,
     )
   }
 
@@ -70,13 +70,13 @@ fun TextDemo() {
     text = "Ellipsis: This text is supposed to ellipsis with max 1 line allowed for this",
     overflow = TextOverflow.Ellipsis,
     modifier = textModifier,
-    maxLines = 1
+    maxLines = 1,
   )
   Text(
     text = "Clip: This text is supposed to clip with max 1 line allowed for this",
     overflow = TextOverflow.Clip,
     modifier = textModifier,
-    maxLines = 1
+    maxLines = 1,
   )
 }
 

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Toggles.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/Toggles.kt
@@ -32,13 +32,13 @@ fun Toggles() {
     Checkbox(
       checked = checked,
       modifier = Modifier.padding(8.dp),
-      onCheckedChange = { checked = !checked }
+      onCheckedChange = { checked = !checked },
     )
     Switch(
       checked = switched,
       colors = SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colorScheme.primary),
       modifier = Modifier.padding(8.dp),
-      onCheckedChange = { switched = it }
+      onCheckedChange = { switched = it },
     )
   }
 
@@ -47,19 +47,19 @@ fun Toggles() {
     RadioButton(selected = selected == "Kotlin", onClick = { selected = "Kotlin" })
     Text(
       text = "Kotlin",
-      modifier = Modifier.clickable(onClick = { selected = "Kotlin" }).padding(start = 4.dp)
+      modifier = Modifier.clickable(onClick = { selected = "Kotlin" }).padding(start = 4.dp),
     )
     Spacer(modifier = Modifier.size(4.dp))
     RadioButton(selected = selected == "Java", onClick = { selected = "Java" })
     Text(
       text = "Java",
-      modifier = Modifier.clickable(onClick = { selected = "Java" }).padding(start = 4.dp)
+      modifier = Modifier.clickable(onClick = { selected = "Java" }).padding(start = 4.dp),
     )
     Spacer(modifier = Modifier.size(4.dp))
     RadioButton(selected = selected == "Swift", onClick = { selected = "Swift" })
     Text(
       text = "Swift",
-      modifier = Modifier.clickable(onClick = { selected = "Swift" }).padding(start = 4.dp)
+      modifier = Modifier.clickable(onClick = { selected = "Swift" }).padding(start = 4.dp),
     )
   }
 
@@ -68,7 +68,7 @@ fun Toggles() {
   Slider(
     value = sliderState,
     modifier = Modifier.fillMaxWidth().padding(8.dp),
-    onValueChange = { newValue -> sliderState = newValue }
+    onValueChange = { newValue -> sliderState = newValue },
   )
 
   var sliderState2 by remember { mutableStateOf(20f) }
@@ -77,6 +77,6 @@ fun Toggles() {
     modifier = Modifier.fillMaxWidth().padding(8.dp),
     valueRange = 0f..100f,
     steps = 5,
-    onValueChange = { newValue -> sliderState2 = newValue }
+    onValueChange = { newValue -> sliderState2 = newValue },
   )
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/UICards.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/UICards.kt
@@ -35,23 +35,23 @@ fun UICards() {
   Text(
     text = "Inbuilt box as container for any Clipping/Alignment controls",
     style = typography.subtitle1,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Material3Card(
     modifier = Modifier.padding(8.dp).fillMaxWidth(),
     backgroundColor = MaterialTheme.colorScheme.primary,
-    shape = RoundedCornerShape(topStart = 16.dp, bottomEnd = 16.dp)
+    shape = RoundedCornerShape(topStart = 16.dp, bottomEnd = 16.dp),
   ) {
     Column {
       Text(
         text = item.title,
         modifier = Modifier.padding(8.dp),
-        color = MaterialTheme.colorScheme.onPrimary
+        color = MaterialTheme.colorScheme.onPrimary,
       )
       Text(
         text = item.subtitle,
         modifier = Modifier.padding(8.dp),
-        color = MaterialTheme.colorScheme.onPrimary
+        color = MaterialTheme.colorScheme.onPrimary,
       )
     }
   }
@@ -61,13 +61,13 @@ fun UICards() {
   Material3Card(
     modifier = Modifier.padding(16.dp).fillMaxWidth(),
     shape = RoundedCornerShape(4.dp),
-    elevation = 4.dp
+    elevation = 4.dp,
   ) {
     Row {
       Image(
         painter = painterResource(id = R.drawable.p3),
         contentDescription = null,
-        modifier = Modifier.size(60.dp)
+        modifier = Modifier.size(60.dp),
       )
       Text(text = item.title, modifier = Modifier.padding(16.dp))
     }
@@ -80,18 +80,13 @@ fun UICards() {
   ListItem(
     text = { Text(item.title) },
     secondaryText = { Text(item.subtitle) },
-    singleLineSecondaryText = false
+    singleLineSecondaryText = false,
   )
   Divider(modifier = Modifier.padding(4.dp))
   ListItem(
     text = { Text(item.title) },
     secondaryText = { Text(item.subtitle) },
-    icon = {
-      Image(
-        painter = painterResource(R.drawable.p3),
-        contentDescription = null,
-      )
-    }
+    icon = { Image(painter = painterResource(R.drawable.p3), contentDescription = null) },
   )
   Divider(modifier = Modifier.padding(4.dp))
   // I am not sure why this is not going multiline for secondaryText...
@@ -100,7 +95,7 @@ fun UICards() {
     secondaryText = { Text(item.subtitle) },
     icon = { Image(painter = painterResource(id = R.drawable.p1), contentDescription = null) },
     overlineText = { Text("Overline text") },
-    singleLineSecondaryText = false
+    singleLineSecondaryText = false,
   )
   Divider()
   ListItem(
@@ -108,7 +103,7 @@ fun UICards() {
     secondaryText = { Text(item.subtitle) },
     icon = { Image(painter = painterResource(id = R.drawable.p2), contentDescription = null) },
     trailing = { Icon(Icons.Default.ShoppingCart, contentDescription = null) },
-    singleLineSecondaryText = false
+    singleLineSecondaryText = false,
   )
   Divider()
 }

--- a/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/WidgetScreen.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/learnwidgets/WidgetScreen.kt
@@ -31,24 +31,22 @@ fun WidgetScreen(onBackPressed: () -> Unit = {}) {
         colors =
           TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer,
-            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
-          )
+            titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+          ),
       )
-    }
+    },
   ) { paddingValues ->
     WidgetScreenContent(modifier = Modifier.padding(paddingValues))
   }
 }
 
 @Composable
-fun WidgetScreenContent(
-  modifier: Modifier = Modifier,
-) {
+fun WidgetScreenContent(modifier: Modifier = Modifier) {
   LazyColumn(
     state = rememberLazyListState(),
     modifier = modifier,
     contentPadding = PaddingValues(16.dp),
-    verticalArrangement = Arrangement.spacedBy(24.dp)
+    verticalArrangement = Arrangement.spacedBy(24.dp),
   ) {
     item { ComponentSection("Buttons", content = { AllButtons() }) }
     item { ComponentSection("Inputs", content = { TextInputs() }) }
@@ -75,14 +73,14 @@ fun ComponentSection(title: String, content: @Composable () -> Unit) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
     tonalElevation = 1.dp,
-    shape = MaterialTheme.shapes.medium
+    shape = MaterialTheme.shapes.medium,
   ) {
     ElevatedCard(modifier = Modifier.fillMaxWidth()) {
       Text(
         text = title,
         style = MaterialTheme.typography.titleLarge,
         fontWeight = FontWeight.Bold,
-        modifier = Modifier.padding(16.dp)
+        modifier = Modifier.padding(16.dp),
       )
       content()
     }

--- a/app/src/main/java/com/guru/composecookbook/ui/templates/TemplateScreen.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/templates/TemplateScreen.kt
@@ -25,7 +25,7 @@ fun TemplateScreen(darkTheme: Boolean) {
         onClick = {
           context.startActivity(TemplatesActivity.newIntent(context, template, darkTheme))
         },
-        modifier = Modifier.fillMaxWidth().padding(12.dp)
+        modifier = Modifier.fillMaxWidth().padding(12.dp),
       ) {
         Text(text = template, modifier = Modifier.padding(8.dp))
       }

--- a/app/src/main/java/com/guru/composecookbook/ui/templates/TemplatesActivity.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/templates/TemplatesActivity.kt
@@ -35,7 +35,7 @@ class TemplatesActivity : ComponentActivity() {
   @OptIn(
     ExperimentalMaterial3Api::class,
     ExperimentalAnimationApi::class,
-    ExperimentalMaterialApi::class
+    ExperimentalMaterialApi::class,
   )
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -64,7 +64,7 @@ class TemplatesActivity : ComponentActivity() {
   ExperimentalMaterial3Api::class,
   ExperimentalFoundationApi::class,
   ExperimentalAnimationApi::class,
-  ExperimentalMaterialApi::class
+  ExperimentalMaterialApi::class,
 )
 @Composable
 fun TemplateApp(templateType: String) {

--- a/app/src/main/java/com/guru/composecookbook/ui/utils/CommomComponents.kt
+++ b/app/src/main/java/com/guru/composecookbook/ui/utils/CommomComponents.kt
@@ -38,7 +38,7 @@ fun TitleText(modifier: Modifier = Modifier, title: String) {
   androidx.compose.material3.Text(
     text = title,
     style = typography.h6.copy(fontSize = 14.sp),
-    modifier = modifier.padding(8.dp)
+    modifier = modifier.padding(8.dp),
   )
 }
 
@@ -47,7 +47,7 @@ fun SubtitleText(subtitle: String, modifier: Modifier = Modifier) {
   androidx.compose.material3.Text(
     text = subtitle,
     style = typography.subtitle2,
-    modifier = modifier.padding(8.dp)
+    modifier = modifier.padding(8.dp),
   )
 }
 
@@ -57,7 +57,7 @@ fun RotateIcon(
   asset: ImageVector,
   angle: Float,
   duration: Int,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   FaIcon(
     faIcon = FaIcons.Play,
@@ -68,7 +68,7 @@ fun RotateIcon(
         .padding(2.dp)
         .graphicsLayer(
           rotationZ = animateFloatAsState(if (state) 0f else angle, tween(duration)).value
-        )
+        ),
   )
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,8 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.2.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+        classpath("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.1.20")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
 }
 
 plugins {
-    id("com.ncorti.ktfmt.gradle") version "0.12.0" apply false
+    id("com.ncorti.ktfmt.gradle") version "0.22.0" apply false
 }
 
 allprojects {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,6 +36,9 @@ dependencies {
     // in order to be able to use "kotlin-android" in the common script
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
 
+    // in order to be able to apply "com.google.devtools.ksp" in the common scripts
+    implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:1.9.22-1.0.17")
+
     // in order to recognize the "plugins" block in the common script
     implementation("com.android.tools.build:gradle:8.2.2")
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,7 +20,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
     }
 }
 
@@ -34,10 +34,14 @@ repositories {
 
 dependencies {
     // in order to be able to use "kotlin-android" in the common script
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.20")
+
+    // in order to be able to apply "org.jetbrains.kotlin.plugin.compose" in the common scripts
+    implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.1.20")
 
     // in order to be able to apply "com.google.devtools.ksp" in the common scripts
-    implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:1.9.22-1.0.17")
+    // (KSP version must match the Kotlin version above)
+    implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:2.1.20-1.0.31")
 
     // in order to recognize the "plugins" block in the common script
     implementation("com.android.tools.build:gradle:8.2.2")

--- a/buildSrc/src/main/kotlin/com/guru/composecookbook/build/configurations/ProjectConfigs.kt
+++ b/buildSrc/src/main/kotlin/com/guru/composecookbook/build/configurations/ProjectConfigs.kt
@@ -1,11 +1,8 @@
 package com.guru.composecookbook.build.configurations
 
-import com.guru.composecookbook.build.dependencies.Versions
-
 object ProjectConfigs {
     const val compileSdkVersion = 34  // Latest supported Android SDK version
     const val minSdkVersion = 25  // Original minSdkVersion
     const val targetSdkVersion = 34  // Matching compileSdkVersion
     const val applicationId = "com.guru.composecookbook"
-    const val kotlinCompilerExtensionVersion = Versions.composeCompiler
 }

--- a/buildSrc/src/main/kotlin/com/guru/composecookbook/build/dependencies/DependencyHandlerExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/guru/composecookbook/build/dependencies/DependencyHandlerExtensions.kt
@@ -33,7 +33,7 @@ fun DependencyHandler.addKotlinTestDependencies() {
 }
 
 fun DependencyHandler.addDataDependencies() {
-    add("kapt", Dependencies.roomCompiler)
+    add("ksp", Dependencies.roomCompiler)
     dataDependencies.forEach {
         add("implementation", it)
     }

--- a/buildSrc/src/main/kotlin/com/guru/composecookbook/build/dependencies/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/guru/composecookbook/build/dependencies/Versions.kt
@@ -2,14 +2,13 @@ package com.guru.composecookbook.build.dependencies
 
 internal object Versions {
     const val compose = "1.6.1"  // Latest stable Compose UI version
-    const val composeCompiler = "1.5.8"  // Latest compiler compatible with Kotlin 1.9.22
     const val activityCompose = "1.8.2"  // Latest stable
     const val pagingCompose = "3.2.1"  // Latest stable
     const val navCompose = "2.7.7"  // Latest stable navigation
     const val constraintLayoutCompose = "1.1.0"  // Latest stable
     const val fontAwesomeCompose = "1.1.0"  // Keeping as is since it's a third-party lib
     const val coilCompose = "2.5.0"  // Latest stable
-    const val kotlin = "1.9.22"  // Latest stable kotlin compatible with Compose
+    const val kotlin = "2.1.20"  // Kotlin 2.x with the K2 compiler
     const val coroutines = "1.7.3"  // Latest stable
     const val androidLifecycleGrouped = "2.7.0"  // Latest stable
     const val flinger = "1.0.5"  // Keeping as is since it's a third-party lib

--- a/buildSrc/src/main/kotlin/common-compose-module-configs-script-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-compose-module-configs-script-plugin.gradle.kts
@@ -3,6 +3,7 @@ import com.guru.composecookbook.build.configurations.ProjectConfigs
 plugins {
     id("com.android.library")
     id("kotlin-android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -19,13 +20,10 @@ android {
     }
     kotlinOptions {
         jvmTarget = "17"
-        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
     }
     buildFeatures {
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = ProjectConfigs.kotlinCompilerExtensionVersion
     }
 }
 

--- a/buildSrc/src/main/kotlin/common-kotlin-module-configs-script-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-kotlin-module-configs-script-plugin.gradle.kts
@@ -3,7 +3,7 @@ import com.guru.composecookbook.build.configurations.ProjectConfigs
 plugins {
     id("com.android.library")
     id("kotlin-android")
-    id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {

--- a/buildSrc/src/main/kotlin/common-kotlin-module-configs-script-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-kotlin-module-configs-script-plugin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library")
     id("kotlin-android")
     id("com.google.devtools.ksp")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -24,10 +25,6 @@ android {
     
     buildFeatures {
         compose = true
-    }
-    
-    composeOptions {
-        kotlinCompilerExtensionVersion = ProjectConfigs.kotlinCompilerExtensionVersion
     }
 }
 

--- a/components/carousel/build.gradle.kts
+++ b/components/carousel/build.gradle.kts
@@ -1,19 +1,15 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.carousel"
-}
+android { namespace = "com.guru.composecookbook.carousel" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":data"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/components/carousel/src/main/java/com/guru/composecookbook/carousel/CarouselDot.kt
+++ b/components/carousel/src/main/java/com/guru/composecookbook/carousel/CarouselDot.kt
@@ -21,7 +21,7 @@ fun CarouselDot(selected: Boolean, color: Color, icon: ImageVector) {
     imageVector = icon,
     modifier = Modifier.padding(4.dp).size(12.dp),
     contentDescription = null,
-    tint = if (selected) color else Color.Gray
+    tint = if (selected) color else Color.Gray,
   )
 }
 

--- a/components/carousel/src/main/java/com/guru/composecookbook/carousel/CarouselLayout.kt
+++ b/components/carousel/src/main/java/com/guru/composecookbook/carousel/CarouselLayout.kt
@@ -52,7 +52,7 @@ fun CarouselItem(item: Item) {
       contentScale = ContentScale.Crop,
       contentDescription = null,
       modifier =
-        Modifier.padding(18.dp).fillMaxWidth().height(180.dp).clip(RoundedCornerShape(12.dp))
+        Modifier.padding(18.dp).fillMaxWidth().height(180.dp).clip(RoundedCornerShape(12.dp)),
     )
     Text(
       text = item.title,
@@ -68,7 +68,7 @@ fun CarouselItemCircle(item: Item) {
     painter = painterResource(id = item.imageId),
     contentDescription = null,
     contentScale = ContentScale.Crop,
-    modifier = Modifier.padding(16.dp).size(160.dp).clip(CircleShape)
+    modifier = Modifier.padding(16.dp).size(160.dp).clip(CircleShape),
   )
 }
 
@@ -82,20 +82,20 @@ fun CarouselItemCard(item: Item, pagerState: PagerState, selectedPage: MutableSt
     modifier = Modifier.size(animateDpAsState(animateSize).value).padding(24.dp),
     shape = RoundedCornerShape(16.dp),
     backgroundColor = green200,
-    contentColor = MaterialTheme.colorScheme.onPrimary
+    contentColor = MaterialTheme.colorScheme.onPrimary,
   ) {
     Column {
       Text(
         text = item.title,
         modifier = Modifier.align(Alignment.CenterHorizontally).padding(8.dp),
-        style = typography.body2
+        style = typography.body2,
       )
       Image(
         painter = painterResource(id = item.imageId),
         contentScale = ContentScale.Crop,
         contentDescription = null,
         modifier =
-          Modifier.padding(4.dp).align(Alignment.CenterHorizontally).size(100.dp).clip(CircleShape)
+          Modifier.padding(4.dp).align(Alignment.CenterHorizontally).size(100.dp).clip(CircleShape),
       )
     }
   }
@@ -105,7 +105,7 @@ fun CarouselItemCard(item: Item, pagerState: PagerState, selectedPage: MutableSt
 private fun ColumnScope.PrepareFirstPager(
   pagerState: PagerState,
   items: List<Item>,
-  selectedPage: MutableState<Int>
+  selectedPage: MutableState<Int>,
 ) {
   Pager(state = pagerState, modifier = Modifier.height(200.dp)) {
     val item = items[commingPage]
@@ -118,7 +118,7 @@ private fun ColumnScope.PrepareFirstPager(
       CarouselDot(
         selected = index == selectedPage.value,
         MaterialTheme.colorScheme.primary,
-        Icons.Filled.Lens
+        Icons.Filled.Lens,
       )
     }
   }
@@ -130,7 +130,7 @@ private fun ColumnScope.PrepareFirstPager(
 private fun ColumnScope.PrepareSecondPager(
   pagerState: PagerState,
   items: List<Item>,
-  selectedPage: MutableState<Int>
+  selectedPage: MutableState<Int>,
 ) {
   Pager(state = pagerState, modifier = Modifier.height(200.dp)) {
     val item = items[commingPage]
@@ -142,7 +142,7 @@ private fun ColumnScope.PrepareSecondPager(
       CarouselDot(
         selected = index == selectedPage.value,
         MaterialTheme.colorScheme.error,
-        Icons.Filled.Favorite
+        Icons.Filled.Favorite,
       )
     }
   }
@@ -153,7 +153,7 @@ private fun ColumnScope.PrepareSecondPager(
 private fun ColumnScope.PrepareThirdPager(
   pagerState: PagerState,
   items: List<Item>,
-  selectedPage: MutableState<Int>
+  selectedPage: MutableState<Int>,
 ) {
   Pager(state = pagerState, modifier = Modifier.height(350.dp)) {
     val item = items[commingPage]
@@ -165,7 +165,7 @@ private fun ColumnScope.PrepareThirdPager(
       CarouselDot(
         selected = index == selectedPage.value,
         MaterialTheme.colorScheme.secondary,
-        Icons.Filled.Album
+        Icons.Filled.Album,
       )
     }
   }

--- a/components/carousel/src/main/java/com/guru/composecookbook/carousel/Pager.kt
+++ b/components/carousel/src/main/java/com/guru/composecookbook/carousel/Pager.kt
@@ -21,7 +21,7 @@ fun Pager(
   state: PagerState,
   orientation: Orientation = Orientation.Horizontal,
   offscreenLimit: Int = 2,
-  content: @Composable PagerScope.() -> Unit
+  content: @Composable PagerScope.() -> Unit,
 ) {
   var pageSize by remember { mutableStateOf(0) }
   val coroutineScope = rememberCoroutineScope()
@@ -44,7 +44,7 @@ fun Pager(
           rememberDraggableState { deltaInPx ->
             coroutineScope.calculateNewPosition(deltaInPx, state, pageSize, offscreenLimit)
           },
-      )
+      ),
   ) { measurables, constraints ->
     layout(constraints.maxWidth, constraints.maxHeight) {
       val currentPage = state.currentPage
@@ -70,12 +70,12 @@ fun Pager(
           if (orientation == Orientation.Horizontal) {
             placeable.placeRelative(
               x = xCenterOffset + ((page - (currentPage - offset)) * placeable.width).roundToInt(),
-              y = yCenterOffset
+              y = yCenterOffset,
             )
           } else {
             placeable.placeRelative(
               x = xCenterOffset,
-              y = yCenterOffset + ((page - (currentPage - offset)) * placeable.height).roundToInt()
+              y = yCenterOffset + ((page - (currentPage - offset)) * placeable.height).roundToInt(),
             )
           }
         }
@@ -86,7 +86,7 @@ fun Pager(
 @Composable
 private fun PagerState.PrepareContent(
   offscreenLimit: Int,
-  content: @Composable PagerScope.() -> Unit
+  content: @Composable PagerScope.() -> Unit,
 ) {
   val minPage = (currentPage - offscreenLimit).coerceAtLeast(minPage)
   val maxPage = (currentPage + offscreenLimit).coerceAtMost(maxPage)
@@ -102,7 +102,7 @@ private fun CoroutineScope.calculateNewPosition(
   delta: Float,
   state: PagerState,
   pageSize: Int,
-  offscreenLimit: Int
+  offscreenLimit: Int,
 ) {
   launch {
     with(state) {

--- a/components/carousel/src/main/java/com/guru/composecookbook/carousel/SelectionState.kt
+++ b/components/carousel/src/main/java/com/guru/composecookbook/carousel/SelectionState.kt
@@ -2,5 +2,5 @@ package com.guru.composecookbook.carousel
 
 enum class SelectionState {
   Selected,
-  Undecided
+  Undecided,
 }

--- a/components/charts/build.gradle.kts
+++ b/components/charts/build.gradle.kts
@@ -2,19 +2,15 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.charts"
-}
+android { namespace = "com.guru.composecookbook.charts" }
 
 dependencies {
-    implementation(project(":theme"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/components/charts/src/main/java/com/guru/composecookbook/charts/Charts.kt
+++ b/components/charts/src/main/java/com/guru/composecookbook/charts/Charts.kt
@@ -82,7 +82,7 @@ fun Charts() {
             LineChart(
               yAxisValues = createRandomFloatList(),
               modifier = Modifier.width(150.dp).height(100.dp),
-              lineColors = listOf(tiktokBlue, tiktokRed)
+              lineColors = listOf(tiktokBlue, tiktokRed),
             )
           }
           Card(modifier = Modifier.padding(16.dp), elevation = 16.dp) {
@@ -90,12 +90,12 @@ fun Charts() {
               LineChart(
                 yAxisValues = increasingChart5Times,
                 modifier = Modifier.width(160.dp).height(100.dp),
-                lineColors = listOf(tiktokBlue, blue200)
+                lineColors = listOf(tiktokBlue, blue200),
               )
               LineChart(
                 yAxisValues = increasingChart10Times,
                 modifier = Modifier.width(160.dp).height(100.dp),
-                lineColors = listOf(orange200, orange700)
+                lineColors = listOf(orange200, orange700),
               )
             }
           }
@@ -108,7 +108,7 @@ fun Charts() {
           BarCharts(
             modifier = Modifier.fillMaxWidth().height(150.dp).padding(top = 4.dp),
             yAxisValues = createRandomFloatList(),
-            barColors = instagramGradient
+            barColors = instagramGradient,
           )
         }
       }
@@ -138,7 +138,7 @@ fun LineChart(
   lineColors: List<Color> =
     listOf(
       androidx.compose.material.MaterialTheme.colors.primary,
-      androidx.compose.material.MaterialTheme.colors.primary
+      androidx.compose.material.MaterialTheme.colors.primary,
     ),
   lineWidth: Float = 4f,
   yAxisValues: List<Float>,
@@ -164,8 +164,8 @@ fun LineChart(
       animationSpec =
         infiniteRepeatable(
           animation = tween(500, easing = LinearEasing),
-          repeatMode = RepeatMode.Reverse
-        )
+          repeatMode = RepeatMode.Reverse,
+        ),
     )
   val opacity by
     infiniteTransition.animateFloat(
@@ -174,8 +174,8 @@ fun LineChart(
       animationSpec =
         infiniteRepeatable(
           animation = tween(500, easing = LinearEasing),
-          repeatMode = RepeatMode.Reverse
-        )
+          repeatMode = RepeatMode.Reverse,
+        ),
     )
 
   Canvas(modifier = modifier.padding(8.dp)) {
@@ -200,14 +200,14 @@ fun LineChart(
     drawPath(
       path = path,
       brush = Brush.linearGradient(lineColors),
-      style = Stroke(width = lineWidth)
+      style = Stroke(width = lineWidth),
     )
     if (shouldDrawLiveDot) {
       drawCircle(
         lineColors.first(),
         radius,
         Offset(last * scaleX, size.height - (yValues[last] * scaleY) + yMove),
-        opacity
+        opacity,
       )
     }
   }
@@ -220,7 +220,7 @@ fun BarCharts(
     listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.primary),
   barWidth: Float = 20f,
   yAxisValues: List<Float>,
-  shouldAnimate: Boolean = true
+  shouldAnimate: Boolean = true,
 ) {
   val x = remember { Animatable(0f) }
   val yValues = remember { yAxisValues }
@@ -246,7 +246,7 @@ fun BarCharts(
         topLeft = Offset(xOffset, yOffset),
         width = barWidth,
         height = size.height - yOffset,
-        barColors
+        barColors,
       )
     }
   }
@@ -287,7 +287,7 @@ fun DrawScope.drawPieSlice(color: Color, size: Size, startAngle: Float, sweepAng
     size = size,
     startAngle = startAngle,
     sweepAngle = sweepAngle,
-    useCenter = true
+    useCenter = true,
   )
 }
 

--- a/components/colorpicker/build.gradle.kts
+++ b/components/colorpicker/build.gradle.kts
@@ -1,18 +1,14 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.colorpicker"
-}
+android { namespace = "com.guru.composecookbook.colorpicker" }
 
 dependencies {
-    implementation(project(":theme"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/components/colorpicker/src/main/java/com/guru/composecookbook/colorpicker/ColorPicker.kt
+++ b/components/colorpicker/src/main/java/com/guru/composecookbook/colorpicker/ColorPicker.kt
@@ -48,7 +48,7 @@ fun ColorPicker(onColorSelected: (Color) -> Unit) {
   Text(
     text = "Color picker with draggable",
     style = typography.subtitle2,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   val screenWidth = LocalConfiguration.current.screenWidthDp.dp
   val screenWidthInPx = with(LocalDensity.current) { screenWidth.toPx() }
@@ -84,7 +84,7 @@ fun ColorPicker(onColorSelected: (Color) -> Unit) {
         Modifier.offset { IntOffset(dragOffset.value.roundToInt(), 0) }
           .border(
             border = BorderStroke(4.dp, MaterialTheme.colorScheme.onSurface),
-            shape = CircleShape
+            shape = CircleShape,
           )
           .draggable(
             orientation = Orientation.Horizontal,
@@ -94,8 +94,8 @@ fun ColorPicker(onColorSelected: (Color) -> Unit) {
                 dragOffset.value = newValue.coerceIn(minPx, maxPx)
                 activeColor = getActiveColor(dragOffset.value, screenWidthInPx)
                 onColorSelected.invoke(activeColor)
-              }
-          )
+              },
+          ),
     )
   }
 }

--- a/components/comingsoon/build.gradle.kts
+++ b/components/comingsoon/build.gradle.kts
@@ -1,19 +1,15 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.comingsoon"
-}
+android { namespace = "com.guru.composecookbook.comingsoon" }
 
 dependencies {
-    implementation(project(":animations:lottie"))
-    implementation(project(":theme"))
+  implementation(project(":animations:lottie"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/components/comingsoon/src/main/java/com/guru/composecookbook/comingsoon/ComingSoon.kt
+++ b/components/comingsoon/src/main/java/com/guru/composecookbook/comingsoon/ComingSoon.kt
@@ -23,13 +23,13 @@ fun ComingSoon() {
         text = "Coming Soon",
         style = typography.h5,
         modifier = Modifier.padding(12.dp).fillMaxWidth(),
-        textAlign = TextAlign.Center
+        textAlign = TextAlign.Center,
       )
       Text(
         text = "work in progress",
         style = typography.subtitle2,
         textAlign = TextAlign.Center,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
       )
     }
   }

--- a/components/fab/build.gradle.kts
+++ b/components/fab/build.gradle.kts
@@ -1,16 +1,10 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.fab"
-}
+android { namespace = "com.guru.composecookbook.fab" }
 
-dependencies {
-    addComposeOfficialDependencies()
-}
+dependencies { addComposeOfficialDependencies() }

--- a/components/fab/src/main/java/com/guru/composecookbook/fab/AnimatingFabContent.kt
+++ b/components/fab/src/main/java/com/guru/composecookbook/fab/AnimatingFabContent.kt
@@ -33,7 +33,7 @@ fun AnimatingFabContent(
   icon: @Composable () -> Unit,
   text: @Composable () -> Unit,
   modifier: Modifier = Modifier,
-  extended: Boolean = true
+  extended: Boolean = true,
 ) {
   val currentState = if (extended) ExpandableFabStates.Extended else ExpandableFabStates.Collapsed
   val transition = updateTransition(targetState = currentState, label = "transition")
@@ -45,19 +45,19 @@ fun AnimatingFabContent(
           ExpandableFabStates.Extended isTransitioningTo ExpandableFabStates.Collapsed ->
             tween(
               easing = LinearEasing,
-              durationMillis = (duration / 12f * 5).roundToInt() // 5 out of 12 frames
+              durationMillis = (duration / 12f * 5).roundToInt(), // 5 out of 12 frames
             )
           ExpandableFabStates.Collapsed isTransitioningTo ExpandableFabStates.Extended -> {
             tween(
               easing = LinearEasing,
               delayMillis = (duration / 3f).roundToInt(), // 4 out of 12 frames
-              durationMillis = (duration / 12f * 5).roundToInt() // 5 out of 12 frames
+              durationMillis = (duration / 12f * 5).roundToInt(), // 5 out of 12 frames
             )
           }
           else -> snap()
         }
       },
-      label = "opacityAnim"
+      label = "opacityAnim",
     ) {
       when (it) {
         ExpandableFabStates.Collapsed -> 0f
@@ -77,7 +77,7 @@ fun AnimatingFabContent(
           else -> snap()
         }
       },
-      label = "widthAnimation"
+      label = "widthAnimation",
     ) {
       when (it) {
         ExpandableFabStates.Collapsed -> 0f
@@ -98,7 +98,7 @@ private fun IconAndTextRow(
   text: @Composable () -> Unit,
   opacityProgress: () -> Float, // Functions instead of Floats, to slightly improve performance
   widthProgress: () -> Float,
-  modifier: Modifier
+  modifier: Modifier,
 ) {
   Layout(
     modifier = modifier,
@@ -126,11 +126,11 @@ private fun IconAndTextRow(
     layout(width.roundToInt(), height) {
       iconPlaceable.placeRelative(
         iconPadding.roundToInt(),
-        constraints.maxHeight / 2 - iconPlaceable.height / 2
+        constraints.maxHeight / 2 - iconPlaceable.height / 2,
       )
       textPlaceable.placeRelative(
         (iconPlaceable.width + iconPadding * 2).roundToInt(),
-        constraints.maxHeight / 2 - textPlaceable.height / 2
+        constraints.maxHeight / 2 - textPlaceable.height / 2,
       )
     }
   }
@@ -138,5 +138,5 @@ private fun IconAndTextRow(
 
 private enum class ExpandableFabStates {
   Collapsed,
-  Extended
+  Extended,
 }

--- a/components/tags/build.gradle.kts
+++ b/components/tags/build.gradle.kts
@@ -1,18 +1,14 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.tags"
-}
+android { namespace = "com.guru.composecookbook.tags" }
 
 dependencies {
-    implementation(project(":theme"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/components/tags/src/main/java/com/guru/composecookbook/tags/InterestTag.kt
+++ b/components/tags/src/main/java/com/guru/composecookbook/tags/InterestTag.kt
@@ -26,7 +26,7 @@ interface TagColors {
 @Immutable
 private class DefaultTagColors(
   private val backgroundColor: Color,
-  private val contentColor: Color
+  private val contentColor: Color,
 ) : TagColors {
   @Composable
   override fun backgroundColor(enabled: Boolean): State<Color> {
@@ -43,7 +43,7 @@ object TagDefaults {
   @Composable
   fun tagColors(
     backgroundColor: Color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .2f),
-    contentColor: Color = MaterialTheme.colorScheme.primary
+    contentColor: Color = MaterialTheme.colorScheme.primary,
   ): TagColors = DefaultTagColors(backgroundColor = backgroundColor, contentColor = contentColor)
 }
 
@@ -54,7 +54,7 @@ fun InterestTag(
   colors: TagColors = TagDefaults.tagColors(),
   shape: Shape = RoundedCornerShape(4.dp),
   style: TextStyle = typography.body2.copy(fontWeight = FontWeight.Bold),
-  onClick: () -> Unit = {}
+  onClick: () -> Unit = {},
 ) {
   val tagModifier =
     modifier
@@ -67,6 +67,6 @@ fun InterestTag(
     text = text,
     color = colors.contentColor(enabled = true).value,
     modifier = tagModifier,
-    style = style
+    style = style,
   )
 }

--- a/components/verticalgrid/build.gradle.kts
+++ b/components/verticalgrid/build.gradle.kts
@@ -1,16 +1,10 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.verticalgrid"
-}
+android { namespace = "com.guru.composecookbook.verticalgrid" }
 
-dependencies {
-    addComposeOfficialDependencies()
-}
+dependencies { addComposeOfficialDependencies() }

--- a/components/verticalgrid/src/main/java/com/guru/composecookbook/verticalgrid/StaggeredVerticalGrid.kt
+++ b/components/verticalgrid/src/main/java/com/guru/composecookbook/verticalgrid/StaggeredVerticalGrid.kt
@@ -27,7 +27,7 @@ import kotlin.math.ceil
 fun StaggeredVerticalGrid(
   modifier: Modifier = Modifier,
   maxColumnWidth: Dp,
-  content: @Composable () -> Unit
+  content: @Composable () -> Unit,
 ) {
   Layout(content = content, modifier = modifier) { measurables, constraints ->
     val placeableXY: MutableMap<Placeable, Pair<Int, Int>> = mutableMapOf()
@@ -53,7 +53,7 @@ fun StaggeredVerticalGrid(
       placeables.forEach { placeable ->
         placeable.placeRelative(
           x = placeableXY.getValue(placeable).first,
-          y = placeableXY.getValue(placeable).second
+          y = placeableXY.getValue(placeable).second,
         )
       }
     }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,14 +1,10 @@
 plugins {
-    /**
-     * See [common-kotlin-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-kotlin-module-configs-script-plugin")
+  /** See [common-kotlin-module-configs-script-plugin.gradle.kts] file */
+  id("common-kotlin-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.data"
-}
+android { namespace = "com.guru.composecookbook.data" }
 
 dependencies {
-    implementation(com.guru.composecookbook.build.dependencies.Dependencies.composeRuntime)
+  implementation(com.guru.composecookbook.build.dependencies.Dependencies.composeRuntime)
 }

--- a/data/src/main/java/com/guru/composecookbook/data/AlbumsDataProvider.kt
+++ b/data/src/main/java/com/guru/composecookbook/data/AlbumsDataProvider.kt
@@ -11,7 +11,7 @@ object AlbumsDataProvider {
       "Top Charts",
       "Recommended for today",
       "Bollywood",
-      "Acoustic only"
+      "Acoustic only",
     )
 
   val album =
@@ -20,7 +20,7 @@ object AlbumsDataProvider {
       artist = "Adele",
       song = "Someone like you",
       descriptions = "Album by Adele-2016",
-      imageId = R.drawable.adele21
+      imageId = R.drawable.adele21,
     )
 
   val albums =
@@ -31,7 +31,7 @@ object AlbumsDataProvider {
         song = "Perfect",
         descriptions = "Album by Ed Sheeran-2016",
         imageId = R.drawable.edsheeran,
-        genre = "Pop"
+        genre = "Pop",
       ),
       Album(
         id = 2,
@@ -39,7 +39,7 @@ object AlbumsDataProvider {
         song = "Havana",
         descriptions = "Album by Camelia Cabello-2016",
         imageId = R.drawable.camelia,
-        genre = "R&B"
+        genre = "R&B",
       ),
       Album(
         id = 3,
@@ -47,7 +47,7 @@ object AlbumsDataProvider {
         song = "Kill this love",
         descriptions = "Album by BlackPink-2016",
         imageId = R.drawable.bp,
-        genre = "K-pop"
+        genre = "K-pop",
       ),
       Album(
         id = 4,
@@ -55,7 +55,7 @@ object AlbumsDataProvider {
         song = "Photograph",
         descriptions = "Album by Ed Sheeran-2016",
         imageId = R.drawable.ed2,
-        genre = "Acoustic"
+        genre = "Acoustic",
       ),
       Album(
         id = 5,
@@ -63,7 +63,7 @@ object AlbumsDataProvider {
         song = "Born to die",
         descriptions = "Album by Lana del ray-2014",
         imageId = R.drawable.lana,
-        genre = "Jazz"
+        genre = "Jazz",
       ),
       Album(
         id = 6,
@@ -71,7 +71,7 @@ object AlbumsDataProvider {
         song = "Location",
         descriptions = "Album by Khalid-2019",
         imageId = R.drawable.khalid,
-        genre = "RnB"
+        genre = "RnB",
       ),
       Album(
         id = 7,
@@ -79,7 +79,7 @@ object AlbumsDataProvider {
         song = "Hello",
         descriptions = "Album by Adele-2019",
         imageId = R.drawable.adele,
-        genre = "Pop"
+        genre = "Pop",
       ),
       Album(
         id = 8,
@@ -87,7 +87,7 @@ object AlbumsDataProvider {
         song = "Stay With Me",
         descriptions = "Album by Ed Sheeran-2016",
         imageId = R.drawable.sam,
-        genre = "Pop"
+        genre = "Pop",
       ),
       Album(
         id = 9,
@@ -95,7 +95,7 @@ object AlbumsDataProvider {
         song = "Bad Guy",
         descriptions = "Album by Billie Eilish-2016",
         imageId = R.drawable.billie,
-        genre = "Pop"
+        genre = "Pop",
       ),
       Album(
         id = 10,
@@ -103,7 +103,7 @@ object AlbumsDataProvider {
         song = "Break My Heart",
         descriptions = "Album by Dua Lipa-2016",
         imageId = R.drawable.dualipa,
-        genre = "Music"
+        genre = "Music",
       ),
       Album(
         id = 11,
@@ -111,7 +111,7 @@ object AlbumsDataProvider {
         song = "Dance Monkey",
         descriptions = "Album by Tones & I-2019",
         imageId = R.drawable.dancemonkey,
-        genre = "Party"
+        genre = "Party",
       ),
       Album(
         id = 12,
@@ -119,7 +119,7 @@ object AlbumsDataProvider {
         song = "Happier",
         descriptions = "Album by Marshmello-2016",
         imageId = R.drawable.marsh,
-        genre = "DJ"
+        genre = "DJ",
       ),
       Album(
         id = 13,
@@ -127,7 +127,7 @@ object AlbumsDataProvider {
         song = "The Eminem Show",
         descriptions = "Album by Eminem-2019",
         imageId = R.drawable.eminem,
-        genre = "Rap"
+        genre = "Rap",
       ),
       Album(
         id = 14,
@@ -135,7 +135,7 @@ object AlbumsDataProvider {
         song = "Starboy",
         descriptions = "Album by The Weekend-2016",
         imageId = R.drawable.weekend,
-        genre = "Mood"
+        genre = "Mood",
       ),
       Album(
         id = 15,
@@ -143,7 +143,7 @@ object AlbumsDataProvider {
         song = "Smile",
         descriptions = "Album by Katy Perry-2016",
         imageId = R.drawable.katy,
-        genre = "Chill"
+        genre = "Chill",
       ),
       Album(
         id = 16,
@@ -151,7 +151,7 @@ object AlbumsDataProvider {
         song = "Senorita",
         descriptions = "Album by Shawn Mendes-2016",
         imageId = R.drawable.shawn,
-        genre = "Latin"
+        genre = "Latin",
       ),
       Album(
         id = 17,
@@ -159,7 +159,7 @@ object AlbumsDataProvider {
         song = "Wolves",
         descriptions = "Album by Selena Gomez-2016",
         imageId = R.drawable.wolves,
-        genre = "Rock"
+        genre = "Rock",
       ),
       Album(
         id = 18,
@@ -167,7 +167,7 @@ object AlbumsDataProvider {
         song = "Someone Like You",
         descriptions = "Album by Adele 21-2016",
         imageId = R.drawable.adele21,
-        genre = "Solo"
+        genre = "Solo",
       ),
       Album(
         id = 19,
@@ -175,7 +175,7 @@ object AlbumsDataProvider {
         song = "Believer",
         descriptions = "Album by Imagine Dragon-2017",
         imageId = R.drawable.imagindragon,
-        genre = "Pop"
+        genre = "Pop",
       ),
       Album(
         id = 20,
@@ -183,7 +183,7 @@ object AlbumsDataProvider {
         song = "Impossible",
         descriptions = "Album by James Arthur-2016",
         imageId = R.drawable.james,
-        genre = "Pop"
+        genre = "Pop",
       ),
     )
 }

--- a/data/src/main/java/com/guru/composecookbook/data/DemoDataProvider.kt
+++ b/data/src/main/java/com/guru/composecookbook/data/DemoDataProvider.kt
@@ -12,98 +12,98 @@ object DemoDataProvider {
         1,
         "Fresh Vegges and Greens",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food1
+        R.drawable.food1,
       ),
       Item(
         2,
         "Best blue berries",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food2
+        R.drawable.food2,
       ),
       Item(
         3,
         "Cherries La Bloom",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food3
+        R.drawable.food3,
       ),
       Item(
         4,
         "Fruits everyday",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food4
+        R.drawable.food4,
       ),
       Item(
         5,
         "Sweet and sour",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food5
+        R.drawable.food5,
       ),
       Item(
         6,
         "Pancakes for everyone",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food6
+        R.drawable.food6,
       ),
       Item(
         7,
         "Cupcakes and sparkle",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food7
+        R.drawable.food7,
       ),
       Item(
         8,
         "Best Burgers shop",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food8
+        R.drawable.food8,
       ),
       Item(
         9,
         "Coffee of India",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food9
+        R.drawable.food9,
       ),
       Item(
         10,
         "Pizza boy town",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food10
+        R.drawable.food10,
       ),
       Item(
         11,
         "Burgers and Chips",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food11
+        R.drawable.food11,
       ),
       Item(
         12,
         "Breads and butter",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food12
+        R.drawable.food12,
       ),
       Item(
         13,
         "Cupcake factory",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food13
+        R.drawable.food13,
       ),
       Item(
         14,
         "Breakfast paradise",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food14
+        R.drawable.food14,
       ),
       Item(
         15,
         "Cake and Bake",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food15
+        R.drawable.food15,
       ),
       Item(
         16,
         "Brunch and Stakes",
         "Very awesome list item has very awesome subtitle. This is bit long",
-        R.drawable.food16
-      )
+        R.drawable.food16,
+      ),
     )
 
   val item =
@@ -111,7 +111,7 @@ object DemoDataProvider {
       1,
       "Awesome List Item",
       "Very awesome list item has very awesome subtitle. This is bit long",
-      R.drawable.food6
+      R.drawable.food6,
     )
 
   val tweet =
@@ -125,7 +125,7 @@ object DemoDataProvider {
       100,
       12,
       15,
-      "Twitter for web"
+      "Twitter for web",
     )
 
   val tweetList =
@@ -137,21 +137,21 @@ object DemoDataProvider {
         handle = "@google",
         authorImageId = R.drawable.p1,
         tweetImageId = R.drawable.food16,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 3,
         author = "Amazon",
         handle = "@Amazon",
         authorImageId = R.drawable.p2,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 4,
         author = "Facebook",
         handle = "@Facebook",
         authorImageId = R.drawable.p3,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 5,
@@ -159,7 +159,7 @@ object DemoDataProvider {
         handle = "@Instagram",
         authorImageId = R.drawable.p4,
         tweetImageId = R.drawable.food15,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 6,
@@ -167,7 +167,7 @@ object DemoDataProvider {
         handle = "@Twitter",
         authorImageId = R.drawable.p5,
         tweetImageId = R.drawable.food3,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 7,
@@ -175,35 +175,35 @@ object DemoDataProvider {
         handle = "@Netflix",
         authorImageId = R.drawable.p6,
         tweetImageId = R.drawable.food4,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 8,
         author = "Tesla",
         handle = "@Tesla",
         authorImageId = R.drawable.p7,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 9,
         author = "Microsoft",
         handle = "@Microsoft",
         authorImageId = R.drawable.p8,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 3,
         author = "Tencent",
         handle = "@Tencent",
         authorImageId = R.drawable.p9,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 4,
         author = "Snapchat",
         handle = "@Snapchat",
         authorImageId = R.drawable.p10,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 5,
@@ -211,7 +211,7 @@ object DemoDataProvider {
         handle = "@Snapchat",
         authorImageId = R.drawable.p11,
         tweetImageId = R.drawable.food5,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 6,
@@ -219,7 +219,7 @@ object DemoDataProvider {
         handle = "@Tiktok",
         authorImageId = R.drawable.p1,
         tweetImageId = R.drawable.food6,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 7,
@@ -227,35 +227,35 @@ object DemoDataProvider {
         handle = "@Samsung",
         authorImageId = R.drawable.p2,
         tweetImageId = R.drawable.food7,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 8,
         author = "Youtube",
         handle = "@Youtube",
         authorImageId = R.drawable.p3,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 9,
         author = "Gmail",
         handle = "@Gmail",
         authorImageId = R.drawable.p4,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 3,
         author = "Android",
         handle = "@Android",
         authorImageId = R.drawable.p5,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 4,
         author = "Whatsapp",
         handle = "@Whatsapp",
         authorImageId = R.drawable.p6,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 5,
@@ -263,7 +263,7 @@ object DemoDataProvider {
         handle = "@Telegram",
         authorImageId = R.drawable.p7,
         tweetImageId = R.drawable.food8,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 6,
@@ -271,7 +271,7 @@ object DemoDataProvider {
         handle = "@Spotify",
         authorImageId = R.drawable.p8,
         tweetImageId = R.drawable.food9,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 7,
@@ -279,21 +279,21 @@ object DemoDataProvider {
         handle = "@WeChat",
         authorImageId = R.drawable.p9,
         tweetImageId = R.drawable.food10,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 8,
         author = "Airbnb",
         handle = "@Airbnb",
         authorImageId = R.drawable.p10,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 9,
         author = "LinkedIn",
         handle = "@LinkedIn",
         authorImageId = R.drawable.p11,
-        time = "1h"
+        time = "1h",
       ),
       tweet.copy(
         id = 6,
@@ -301,7 +301,7 @@ object DemoDataProvider {
         handle = "@Shazam",
         authorImageId = R.drawable.p8,
         tweetImageId = R.drawable.food11,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 7,
@@ -309,7 +309,7 @@ object DemoDataProvider {
         handle = "@Chrome",
         authorImageId = R.drawable.p9,
         tweetImageId = R.drawable.food12,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 6,
@@ -317,7 +317,7 @@ object DemoDataProvider {
         handle = "@Safari",
         authorImageId = R.drawable.p8,
         tweetImageId = R.drawable.food13,
-        time = "11m"
+        time = "11m",
       ),
       tweet.copy(
         id = 7,
@@ -325,8 +325,8 @@ object DemoDataProvider {
         handle = "@Disney",
         authorImageId = R.drawable.p9,
         tweetImageId = R.drawable.food14,
-        time = "11m"
-      )
+        time = "11m",
+      ),
     )
 
   val homeScreenListItems =
@@ -363,6 +363,6 @@ object DemoDataProvider {
       "DatingApp",
       "TikTok",
       "Paint",
-      "Meditation"
+      "Meditation",
     )
 }

--- a/data/src/main/java/com/guru/composecookbook/data/model/Album.kt
+++ b/data/src/main/java/com/guru/composecookbook/data/model/Album.kt
@@ -9,5 +9,5 @@ data class Album(
   val song: String,
   val descriptions: String,
   val imageId: Int,
-  val swiped: Boolean = false
+  val swiped: Boolean = false,
 ) : Serializable

--- a/data/src/main/java/com/guru/composecookbook/data/model/HomeScreenItems.kt
+++ b/data/src/main/java/com/guru/composecookbook/data/model/HomeScreenItems.kt
@@ -2,19 +2,33 @@ package com.guru.composecookbook.data.model
 
 sealed class HomeScreenItems {
   object Dialogs : HomeScreenItems()
+
   object TabLayout : HomeScreenItems()
+
   object Carousel : HomeScreenItems()
+
   object Layouts : HomeScreenItems()
+
   data class ListView(val type: String = "Vertical") : HomeScreenItems()
+
   object AdvanceLists : HomeScreenItems()
+
   object ConstraintsLayout : HomeScreenItems()
+
   object CollapsingAppBar : HomeScreenItems()
+
   object BottomAppBar : HomeScreenItems()
+
   object BottomSheets : HomeScreenItems()
+
   object Modifiers : HomeScreenItems()
+
   object AndroidViews : HomeScreenItems()
+
   object PullRefresh : HomeScreenItems()
+
   object CustomFling : HomeScreenItems()
+
   object MotionLayout : HomeScreenItems()
 
   val name: String

--- a/data/src/main/java/com/guru/composecookbook/data/model/Item.kt
+++ b/data/src/main/java/com/guru/composecookbook/data/model/Item.kt
@@ -5,5 +5,5 @@ data class Item(
   val title: String,
   val subtitle: String,
   val imageId: Int,
-  val source: String = "demo source"
+  val source: String = "demo source",
 )

--- a/data/src/main/java/com/guru/composecookbook/data/model/Tweet.kt
+++ b/data/src/main/java/com/guru/composecookbook/data/model/Tweet.kt
@@ -11,5 +11,5 @@ data class Tweet(
   val commentsCount: Int,
   val retweetCount: Int,
   val source: String,
-  val tweetImageId: Int = 0
+  val tweetImageId: Int = 0,
 )

--- a/demos/cryptoapp/app/build.gradle.kts
+++ b/demos/cryptoapp/app/build.gradle.kts
@@ -5,46 +5,38 @@ import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 import com.guru.composecookbook.build.dependencies.addThirdPartyUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
-    id("org.jetbrains.kotlin.android")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
+  id("org.jetbrains.kotlin.android")
 }
 
-android {
-    namespace = "com.guru.composecookbook.cryptoapp"
-}
-
+android { namespace = "com.guru.composecookbook.cryptoapp" }
 
 dependencies {
-    implementation(project(":components:charts"))
-    implementation(project(":animations:lottie"))
-    implementation(project(":demos:cryptoapp:data"))
-    implementation(project(":theme"))
-    implementation(project(":data"))
-    implementation("androidx.wear:wear:1.2.0")
+  implementation(project(":components:charts"))
+  implementation(project(":animations:lottie"))
+  implementation(project(":demos:cryptoapp:data"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation("androidx.wear:wear:1.2.0")
 
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
 
-    addCoreAndroidUiDependencies()
-    addThirdPartyUiDependencies()
+  addCoreAndroidUiDependencies()
+  addThirdPartyUiDependencies()
 
-    addCoreAndroidDependencies()
+  addCoreAndroidDependencies()
 
-    val wear_compose_version = "1.0.0-alpha07"
-    implementation("androidx.wear.compose:compose-material:$wear_compose_version")
+  val wear_compose_version = "1.0.0-alpha07"
+  implementation("androidx.wear.compose:compose-material:$wear_compose_version")
 
-    // Foundation is additive, so you can use the mobile version in your Wear OS app.
-    implementation("androidx.wear.compose:compose-foundation:$wear_compose_version")
+  // Foundation is additive, so you can use the mobile version in your Wear OS app.
+  implementation("androidx.wear.compose:compose-foundation:$wear_compose_version")
 
-    // If you are using Compose Navigation, use the Wear OS version (NOT THE MOBILE ONE), that is,
-    // uncomment the line below and update the version number.
-    implementation("androidx.wear.compose:compose-navigation:$wear_compose_version")
+  // If you are using Compose Navigation, use the Wear OS version (NOT THE MOBILE ONE), that is,
+  // uncomment the line below and update the version number.
+  implementation("androidx.wear.compose:compose-navigation:$wear_compose_version")
 }
-android {
-    buildFeatures {
-        viewBinding = true
-    }
-}
+
+android { buildFeatures { viewBinding = true } }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/composewear/AndroidWearActivity.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/composewear/AndroidWearActivity.kt
@@ -74,12 +74,12 @@ class AndroidWearActivity : ComponentActivity() {
 
     Scaffold(
       positionIndicator = { PositionIndicator(scalingLazyListState = scrollState) },
-      vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) }
+      vignette = { Vignette(vignettePosition = VignettePosition.TopAndBottom) },
     ) {
       val navController = rememberSwipeDismissableNavController()
       SwipeDismissableNavHost(
         navController = navController,
-        startDestination = WearScreen.StockList.route
+        startDestination = WearScreen.StockList.route,
       ) {
         composable(route = WearScreen.StockList.route) {
           StockListScreen(scrollState = scrollState, items = pagingItems) { symbol ->
@@ -88,7 +88,7 @@ class AndroidWearActivity : ComponentActivity() {
         }
         composable(
           route = WearScreen.StockDetail.route + "/{$SYMBOL_ID}",
-          arguments = listOf(navArgument(SYMBOL_ID) { type = NavType.StringType })
+          arguments = listOf(navArgument(SYMBOL_ID) { type = NavType.StringType }),
         ) { backStackEntry ->
           val symbol = backStackEntry.arguments?.getString(SYMBOL_ID) ?: "btc"
           val crypto = pagingItems.itemSnapshotList.items.firstOrNull { it.symbol == symbol }
@@ -103,18 +103,18 @@ class AndroidWearActivity : ComponentActivity() {
 fun StockListScreen(
   scrollState: ScalingLazyListState,
   items: LazyPagingItems<Crypto>,
-  onItemSelected: (String) -> Unit
+  onItemSelected: (String) -> Unit,
 ) {
   ScalingLazyColumn(
     state = scrollState,
     modifier =
-      Modifier.fillMaxSize().background(MaterialTheme.colors.background).padding(horizontal = 8.dp)
+      Modifier.fillMaxSize().background(MaterialTheme.colors.background).padding(horizontal = 8.dp),
   ) {
     item {
       Text(
         "Cookbook wear",
         textAlign = TextAlign.Center,
-        modifier = Modifier.fillMaxWidth().padding(8.dp)
+        modifier = Modifier.fillMaxWidth().padding(8.dp),
       )
     }
     items(items.itemCount) {
@@ -132,7 +132,7 @@ fun WearStockListItem(crypto: Crypto, onItemSelected: (String) -> Unit) {
         painter = rememberImagePainter(data = crypto.image),
         modifier = Modifier.size(32.dp).padding(4.dp),
         contentDescription = null,
-        contentScale = ContentScale.Crop
+        contentScale = ContentScale.Crop,
       )
       Column(modifier = Modifier.padding(horizontal = 4.dp)) {
         Text(text = crypto.symbol.uppercase())
@@ -142,7 +142,7 @@ fun WearStockListItem(crypto: Crypto, onItemSelected: (String) -> Unit) {
       LineChart(
         modifier = Modifier.height(40.dp).padding(horizontal = 8.dp).weight(1f),
         yAxisValues = crypto.chartData,
-        lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors
+        lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors,
       )
     }
   }
@@ -155,14 +155,14 @@ fun StockDetailScreen(crypto: Crypto) {
       Modifier.padding(16.dp)
         .background(MaterialTheme.colors.background)
         .verticalScroll(rememberScrollState()),
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Image(
         painter = rememberImagePainter(data = crypto.image),
         modifier = Modifier.size(24.dp).padding(end = 8.dp),
         contentDescription = null,
-        contentScale = ContentScale.Crop
+        contentScale = ContentScale.Crop,
       )
       Text(text = crypto.symbol.uppercase(), fontWeight = FontWeight.Bold)
     }
@@ -170,12 +170,12 @@ fun StockDetailScreen(crypto: Crypto) {
     val plusMinusIndicator = if (crypto.dailyChange > 0) "+" else "-"
     Text(
       text = "$plusMinusIndicator${crypto.dailyChange} (${crypto.dailyChangePercentage}%)",
-      color = if (crypto.dailyChange > 0) green500 else Color.Red
+      color = if (crypto.dailyChange > 0) green500 else Color.Red,
     )
     LineChart(
       modifier = Modifier.height(80.dp).padding(horizontal = 8.dp).fillMaxWidth(),
       yAxisValues = crypto.chartData,
-      lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors
+      lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors,
     )
     StatisticsCard(crypto)
   }
@@ -183,7 +183,7 @@ fun StockDetailScreen(crypto: Crypto) {
 
 @Composable
 fun StatisticsCard(crypto: Crypto) {
-  Card(onClick = { /*TODO*/}, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+  Card(onClick = { /*TODO*/ }, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
     Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
       Text(text = "24H High -  ${crypto.high.roundToTwoDecimals()}")
       Spacer(modifier = Modifier.height(16.dp))
@@ -196,5 +196,6 @@ fun StatisticsCard(crypto: Crypto) {
 
 sealed class WearScreen(val route: String) {
   object StockList : WearScreen("list")
+
   object StockDetail : WearScreen("detail")
 }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/detail/CryptoDetailActivity.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/detail/CryptoDetailActivity.kt
@@ -29,6 +29,7 @@ class CryptoDetailActivity : ComponentActivity() {
 
   companion object {
     const val CRYPTO = "crypto"
+
     fun newIntent(context: Context, crypto: Crypto) =
       Intent(context, CryptoDetailActivity::class.java).apply { putExtra(CRYPTO, crypto) }
   }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/detail/components/CryptoDetailScreen.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/detail/components/CryptoDetailScreen.kt
@@ -71,7 +71,7 @@ fun CryptoDetailScreen(crypto: Crypto, onBack: () -> Unit) {
   Scaffold(
     bottomBar = { CryptoBottomBar(onBack) },
     floatingActionButton = { CryptoFloatingActionButton() },
-    floatingActionButtonPosition = FabPosition.Center
+    floatingActionButtonPosition = FabPosition.Center,
   ) { paddingValues ->
     Box(modifier = Modifier.padding(paddingValues).horizontalGradientBackground(surfaceGradient)) {
       val scrollState = rememberScrollState(0)
@@ -104,19 +104,19 @@ fun CryptoTopSection(crypto: Crypto, scrollState: ScrollState) {
       Image(
         painter = rememberImagePainter(data = crypto.image),
         modifier = Modifier.size(28.dp),
-        contentDescription = null
+        contentDescription = null,
       )
     }
 
     Text(
       text = "${crypto.price.roundToTwoDecimals()} USD",
-      style = typography.h6.copy(fontWeight = FontWeight.ExtraBold)
+      style = typography.h6.copy(fontWeight = FontWeight.ExtraBold),
     )
     Text(
       text =
         "${crypto.dailyChange.roundToTwoDecimals()} " +
           " (${crypto.dailyChangePercentage.roundToTwoDecimals()}%) Today",
-      color = if (crypto.dailyChange > 0) green700 else Color.Red
+      color = if (crypto.dailyChange > 0) green700 else Color.Red,
     )
   }
 }
@@ -126,20 +126,20 @@ fun CryptoCharts(crypto: Crypto) {
   Card(
     modifier = Modifier.padding(vertical = 8.dp),
     elevation = 8.dp,
-    shape = RoundedCornerShape(4.dp)
+    shape = RoundedCornerShape(4.dp),
   ) {
     Column {
       LineChart(
         modifier = Modifier.fillMaxWidth().height(100.dp),
         yAxisValues = crypto.chartData,
-        lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors
+        lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors,
       )
       Spacer(modifier = Modifier.height(10.dp))
       BarCharts(
         modifier = Modifier.fillMaxWidth().height(120.dp),
         yAxisValues = crypto.chartData,
         barColors = gradientBluePurple,
-        barWidth = 2f
+        barWidth = 2f,
       )
     }
   }
@@ -151,7 +151,7 @@ fun CryptoBottomBar(onBack: () -> Unit) {
     IconButton(onClick = onBack) {
       Icon(
         imageVector = Icons.Default.ArrowBack,
-        contentDescription = stringResource(id = R.string.cd_back)
+        contentDescription = stringResource(id = R.string.cd_back),
       )
     }
     IconButton(onClick = {}) { Icon(imageVector = Icons.Default.MoreVert, contentDescription = "") }
@@ -166,7 +166,7 @@ fun CryptoFloatingActionButton() {
     text = { Text(text = "Trade") },
     onClick = { pressed = !pressed },
     containerColor = MaterialTheme.colorScheme.primary,
-    modifier = Modifier.width(animateDpAsState(if (pressed) 200.dp else 120.dp).value)
+    modifier = Modifier.width(animateDpAsState(if (pressed) 200.dp else 120.dp).value),
   )
 }
 
@@ -176,16 +176,14 @@ fun StatisticsSection(crypto: Crypto) {
   Text(
     text = "Statistics",
     modifier = Modifier.padding(top = 24.dp, bottom = 8.dp),
-    style = typography.h5
+    style = typography.h5,
   )
   Card(
     modifier = Modifier.padding(vertical = 8.dp),
     elevation = 8.dp,
-    shape = RoundedCornerShape(4.dp)
+    shape = RoundedCornerShape(4.dp),
   ) {
-    Row(
-      modifier = Modifier.fillMaxWidth().padding(16.dp),
-    ) {
+    Row(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
       Column(modifier = Modifier.weight(1f)) {
         Text(text = "24 High", style = typography.subtitle2)
         Text(text = crypto.high.roundToTwoDecimals(), modifier = valueModifier)
@@ -215,7 +213,7 @@ fun FavSection() {
     Text(
       text = "Favorite Cryptos",
       modifier = Modifier.padding(top = 24.dp, bottom = 8.dp),
-      style = typography.h5
+      style = typography.h5,
     )
     LazyRow { items(items = favCryptos, itemContent = { FavoriteCryptoCard(crypto = it) }) }
   }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/detail/components/FavoriteCryptoCard.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/detail/components/FavoriteCryptoCard.kt
@@ -29,23 +29,23 @@ fun FavoriteCryptoCard(crypto: Crypto) {
         Image(
           painter = rememberImagePainter(data = crypto.image),
           modifier = Modifier.size(24.dp),
-          contentDescription = null
+          contentDescription = null,
         )
         Text(
           text = crypto.name,
           modifier = Modifier.padding(horizontal = 8.dp),
-          style = typography.body2
+          style = typography.body2,
         )
       }
       Text(
         text = crypto.price.roundToTwoDecimals() + " usd",
         style = typography.h6,
-        color = if (crypto.dailyChangePercentage > 0) green500 else Color.Red
+        color = if (crypto.dailyChangePercentage > 0) green500 else Color.Red,
       )
       Text(
         text = "${crypto.dailyChangePercentage.roundToTwoDecimals()} %",
         style = typography.h6,
-        color = if (crypto.dailyChangePercentage > 0) green500 else Color.Red
+        color = if (crypto.dailyChangePercentage > 0) green500 else Color.Red,
       )
     }
   }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/CryptoHomeActivity.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/CryptoHomeActivity.kt
@@ -19,7 +19,9 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 sealed class CryptoHomeInteractionEvents {
   data class AddedToFav(val crypto: Crypto) : CryptoHomeInteractionEvents()
+
   data class OpenDetailScreen(val crypto: Crypto) : CryptoHomeInteractionEvents()
+
   data class RemoveFav(val crypto: Crypto) : CryptoHomeInteractionEvents()
 }
 
@@ -39,7 +41,7 @@ class CryptoHomeActivity : ComponentActivity() {
 
   private fun handleInteractionEvents(
     cryptoHomeInteractionEvents: CryptoHomeInteractionEvents,
-    viewModel: CryptoHomeViewModel
+    viewModel: CryptoHomeViewModel,
   ) {
     when (cryptoHomeInteractionEvents) {
       is CryptoHomeInteractionEvents.AddedToFav -> {
@@ -56,6 +58,7 @@ class CryptoHomeActivity : ComponentActivity() {
 
   companion object {
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, isDarkTheme: Boolean) =
       Intent(context, CryptoHomeActivity::class.java).apply { putExtra(DARK_THEME, isDarkTheme) }
   }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/components/CryptoHomeScreen.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/components/CryptoHomeScreen.kt
@@ -72,7 +72,7 @@ fun CryptoHomeScreen(onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents
   val listScrollState = rememberLazyListState()
   val cryptos = viewModel.getAllCryptos().collectAsLazyPagingItems()
   Scaffold(
-    floatingActionButton = { CryptoFABButton(favCryptos.size) { showFavState = !showFavState } },
+    floatingActionButton = { CryptoFABButton(favCryptos.size) { showFavState = !showFavState } }
   ) { paddingValues ->
     Column(
       modifier =
@@ -101,9 +101,9 @@ fun CryptoFABButton(count: Int, showFavState: () -> Unit) {
         imageVector = Icons.Filled.Favorite,
         tint = Color.Red,
         contentDescription = null,
-        modifier = animateRotationModifier
+        modifier = animateRotationModifier,
       )
-    }
+    },
   )
 }
 
@@ -111,7 +111,7 @@ fun CryptoFABButton(count: Int, showFavState: () -> Unit) {
 fun ShowFavorites(
   showFave: Boolean,
   favCryptos: List<Crypto>,
-  onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents) -> Unit
+  onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents) -> Unit,
 ) {
   Column(
     modifier =
@@ -129,7 +129,7 @@ fun ShowFavorites(
               CryptoHomeInteractionEvents.OpenDetailScreen(crypto = crypto)
             )
           }
-        }
+        },
       )
     }
   }
@@ -144,19 +144,19 @@ fun FavoriteItem(crypto: Crypto, openCryptoDetail: () -> Unit) {
         .clip(RoundedCornerShape(8.dp))
         .clickable(onClick = openCryptoDetail)
         .padding(16.dp),
-    verticalAlignment = Alignment.CenterVertically
+    verticalAlignment = Alignment.CenterVertically,
   ) {
     Image(
       painter = rememberImagePainter(data = crypto.image),
       modifier = Modifier.size(24.dp),
-      contentDescription = null
+      contentDescription = null,
     )
     Text(
       text = crypto.symbol,
       style = typography.h6.copy(fontSize = 20.sp),
       modifier = Modifier.padding(horizontal = 8.dp).height(32.dp),
       color = MaterialTheme.colorScheme.onSurface,
-      textAlign = TextAlign.Center
+      textAlign = TextAlign.Center,
     )
   }
 }
@@ -166,14 +166,14 @@ fun CryptoList(
   cryptos: LazyPagingItems<Crypto>,
   favCryptos: List<Crypto>,
   listScrollState: LazyListState,
-  onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents) -> Unit
+  onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents) -> Unit,
 ) {
   val context = LocalContext.current
 
   LazyColumn(state = listScrollState) {
     items(
       count = cryptos.itemCount,
-      key = { index -> cryptos[index]?.symbol ?: index.toString() }
+      key = { index -> cryptos[index]?.symbol ?: index.toString() },
     ) { index ->
       val crypto = cryptos[index]
       crypto?.let {

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/components/CryptoListItem.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/components/CryptoListItem.kt
@@ -41,7 +41,7 @@ import com.guru.composecookbook.theme.typography
 fun CryptoListItem(
   crypto: Crypto,
   isFav: Boolean = false,
-  onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents) -> Unit
+  onCryptoHomeInteractionEvents: (CryptoHomeInteractionEvents) -> Unit,
 ) {
   Row(
     modifier =
@@ -53,32 +53,32 @@ fun CryptoListItem(
         )
         .padding(16.dp),
     horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically
+    verticalAlignment = Alignment.CenterVertically,
   ) {
     AsyncImage(
       model = crypto.image,
       contentDescription = null,
       modifier = Modifier.size(40.dp).padding(4.dp),
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Column(modifier = Modifier.weight(0.4f)) {
       Text(
         text = crypto.symbol,
         style = typography.h6.copy(fontSize = 16.sp),
-        modifier = Modifier.padding(horizontal = 4.dp)
+        modifier = Modifier.padding(horizontal = 4.dp),
       )
       Text(
         text = "$${crypto.price}",
         style = typography.h6.copy(fontSize = 14.sp),
         textAlign = TextAlign.Center,
-        modifier = Modifier.padding(horizontal = 4.dp)
+        modifier = Modifier.padding(horizontal = 4.dp),
       )
     }
     Column(modifier = Modifier.weight(1f)) {
       LineChart(
         modifier = Modifier.width(100.dp).height(50.dp).align(Alignment.CenterHorizontally),
         yAxisValues = crypto.chartData,
-        lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors
+        lineColors = if (crypto.dailyChange > 0) gradientGreenColors else gradientRedColors,
       )
       Text(
         text =
@@ -87,7 +87,7 @@ fun CryptoListItem(
         style = typography.subtitle2,
         color = if (crypto.dailyChange > 0) green500 else Color.Red,
         textAlign = TextAlign.Center,
-        modifier = Modifier.fillMaxWidth().align(Alignment.End)
+        modifier = Modifier.fillMaxWidth().align(Alignment.End),
       )
     }
     IconToggleButton(
@@ -97,12 +97,12 @@ fun CryptoListItem(
         else {
           onCryptoHomeInteractionEvents(CryptoHomeInteractionEvents.RemoveFav(crypto))
         }
-      }
+      },
     ) {
       Icon(
         imageVector = if (isFav) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
         contentDescription = null,
-        tint = if (isFav) Color.Red else MaterialTheme.colorScheme.onSurface
+        tint = if (isFav) Color.Red else MaterialTheme.colorScheme.onSurface,
       )
     }
   }

--- a/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/components/MyWalletCard.kt
+++ b/demos/cryptoapp/app/src/main/java/com/guru/composecookbook/cryptoapp/ui/home/components/MyWalletCard.kt
@@ -64,7 +64,7 @@ fun MyWalletCard() {
         Modifier.size(28.dp).alpha(0.7f).constrainAs(image) {
           start.linkTo(parent.start)
           top.linkTo(title.bottom, margin = 8.dp)
-        }
+        },
     )
     Text(
       text = "My Wallet",
@@ -75,7 +75,7 @@ fun MyWalletCard() {
           top.linkTo(parent.top)
           start.linkTo(parent.start)
           end.linkTo(parent.end)
-        }
+        },
     )
     Text(
       text = "340.13 USD",
@@ -84,7 +84,7 @@ fun MyWalletCard() {
         Modifier.padding(4.dp).constrainAs(price) {
           top.linkTo(title.bottom)
           start.linkTo(image.end)
-        }
+        },
     )
     Text(
       text = "1.23 ETH",
@@ -94,7 +94,7 @@ fun MyWalletCard() {
         Modifier.padding(start = 4.dp).constrainAs(asset) {
           top.linkTo(price.bottom)
           start.linkTo(image.end)
-        }
+        },
     )
     Text(
       text = "24H: +1.23%",
@@ -104,7 +104,7 @@ fun MyWalletCard() {
         Modifier.padding(4.dp).constrainAs(dailyChange) {
           end.linkTo(parent.end)
           top.linkTo(price.top)
-        }
+        },
     )
     ExtendedFloatingActionButton(
       onClick = { extended = !extended },
@@ -120,12 +120,12 @@ fun MyWalletCard() {
         Icon(
           imageVector = Icons.Default.QrCodeScanner,
           contentDescription = null,
-          tint = MaterialTheme.colorScheme.onSurface
+          tint = MaterialTheme.colorScheme.onSurface,
         )
       },
       text = { Text(text = "Receive") },
       containerColor = Color.Transparent,
-      elevation = FloatingActionButtonDefaults.elevation()
+      elevation = FloatingActionButtonDefaults.elevation(),
     )
     ExtendedFloatingActionButton(
       onClick = { extended = !extended },
@@ -140,7 +140,7 @@ fun MyWalletCard() {
       icon = { Icon(imageVector = Icons.Default.Send, contentDescription = null) },
       text = { Text(text = "Send") },
       containerColor = Color.Transparent,
-      elevation = FloatingActionButtonDefaults.elevation()
+      elevation = FloatingActionButtonDefaults.elevation(),
     )
     Image(
       imageVector = Icons.Default.QrCodeScanner,
@@ -152,7 +152,7 @@ fun MyWalletCard() {
             top.linkTo(receive.bottom, margin = 50.dp)
             start.linkTo(parent.start)
             end.linkTo(parent.end)
-          }
+          },
     )
   }
 }

--- a/demos/cryptoapp/data/build.gradle.kts
+++ b/demos/cryptoapp/data/build.gradle.kts
@@ -3,18 +3,14 @@ import com.guru.composecookbook.build.dependencies.addDataDependencies
 import com.guru.composecookbook.build.dependencies.addNetworkingDependencies
 
 plugins {
-    /**
-     * See [common-kotlin-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-kotlin-module-configs-script-plugin")
+  /** See [common-kotlin-module-configs-script-plugin.gradle.kts] file */
+  id("common-kotlin-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.cryptoapp.data"
-}
+android { namespace = "com.guru.composecookbook.cryptoapp.data" }
 
 dependencies {
-    addCoreAndroidDependencies()
-    addNetworkingDependencies()
-    addDataDependencies()
+  addCoreAndroidDependencies()
+  addNetworkingDependencies()
+  addDataDependencies()
 }

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/CryptoDemoDataProvider.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/CryptoDemoDataProvider.kt
@@ -17,7 +17,7 @@ object CryptoDemoDataProvider {
       1992922,
       12223333.0,
       120234333.99,
-      emptyList()
+      emptyList(),
     )
 
   val demoList = mutableListOf(bitcoin, bitcoin.copy(symbol = "ETH", name = "Ethereum"))

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/DemoDIGraph.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/DemoDIGraph.kt
@@ -37,7 +37,7 @@ object DemoDIGraph {
     return CryptoRepositoryImpl(
       cryptoApi = retrofit.create(CryptoApi::class.java),
       cryptoDao = db.cryptoDao(),
-      cryptoApiMapper = CryptoApiMapper()
+      cryptoApiMapper = CryptoApiMapper(),
     )
   }
 }

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/api/CryptoApi.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/api/CryptoApi.kt
@@ -12,7 +12,7 @@ interface CryptoApi {
   @GET("coins/markets?vs_currency=usd&order=market_cap_desc&sparkline=true")
   suspend fun getAllCrypto(
     @Query("page") page: Int = 1,
-    @Query("per_page") pageSize: Int = 20
+    @Query("per_page") pageSize: Int = 20,
   ): Response<List<CryptoApiResponse>>
 
   @GET("coins/{ticker}")

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/api/CryptoApiMapper.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/api/CryptoApiMapper.kt
@@ -17,6 +17,6 @@ class CryptoApiMapper {
       volume = cryptoApiResponse.total_volume,
       supply = cryptoApiResponse.total_supply,
       marketCap = cryptoApiResponse.market_cap,
-      chartData = cryptoApiResponse.sparkline_in_7d.price
+      chartData = cryptoApiResponse.sparkline_in_7d.price,
     )
 }

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/api/models/CryptoApiResponse.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/api/models/CryptoApiResponse.kt
@@ -13,7 +13,7 @@ data class CryptoApiResponse(
   val price_change_24h: Double,
   val price_change_percentage_24h: Double,
   val total_supply: Double,
-  val sparkline_in_7d: SparkLineData
+  val sparkline_in_7d: SparkLineData,
 )
 
 data class SparkLineData(val price: List<Float>)

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/db/models/Crypto.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/db/models/Crypto.kt
@@ -17,7 +17,7 @@ data class Crypto(
   val marketCap: Long,
   val volume: Double,
   val supply: Double?,
-  val chartData: List<Float>
+  val chartData: List<Float>,
 ) : Serializable {
 
   override fun equals(other: Any?): Boolean {

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/paging/PageNumSource.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/paging/PageNumSource.kt
@@ -23,7 +23,7 @@ class PageNumSource<Value : Any>(
         // 如果可以往上加载更多就设置该参数，否则不设置
         prevKey = if (page == 1) null else page - 1,
         // 加载下一页的key 如果传null就说明到底了
-        nextKey = page.plus(1)
+        nextKey = page.plus(1),
       )
     } catch (e: IOException) {
       // IOException for network failures.

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/repositories/CryptoRepository.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/repositories/CryptoRepository.kt
@@ -5,7 +5,10 @@ import com.guru.composecookbook.cryptoapp.data.db.models.Crypto
 
 interface CryptoRepository {
   suspend fun getPageCryptos(page: Int, pageSize: Int): List<Crypto>
+
   suspend fun getFavourite(): LiveData<List<Crypto>>
+
   suspend fun addFavorite(crypto: Crypto)
+
   suspend fun removeFavorite(crypto: Crypto)
 }

--- a/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/repositories/CryptoRepositoryImpl.kt
+++ b/demos/cryptoapp/data/src/main/java/com/guru/composecookbook/cryptoapp/data/repositories/CryptoRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.guru.composecookbook.cryptoapp.data.db.models.Crypto
 class CryptoRepositoryImpl(
   private val cryptoApi: CryptoApi,
   private val cryptoDao: CryptoDao,
-  private val cryptoApiMapper: CryptoApiMapper
+  private val cryptoApiMapper: CryptoApiMapper,
 ) : CryptoRepository {
 
   @WorkerThread

--- a/demos/datingapp/build.gradle.kts
+++ b/demos/datingapp/build.gradle.kts
@@ -2,22 +2,18 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.datingapp"
-}
+android { namespace = "com.guru.composecookbook.datingapp" }
 
 dependencies {
-    implementation(project(":animations:canvas"))
-    implementation(project(":components:comingsoon"))
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":animations:canvas"))
+  implementation(project(":components:comingsoon"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/DatingHomeActivity.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/DatingHomeActivity.kt
@@ -53,7 +53,7 @@ class DatingHomeActivity : ComponentActivity() {
         val navType = rememberSaveable { mutableStateOf(DatingNavType.PEOPLES) }
         Scaffold(
           topBar = { DatingHomeAppbar(navType) },
-          bottomBar = { DatingBottomBar(navType) }
+          bottomBar = { DatingBottomBar(navType) },
         ) { paddingValues ->
           DatingHomeContent(navType = navType, modifier = Modifier.padding(paddingValues))
         }
@@ -63,6 +63,7 @@ class DatingHomeActivity : ComponentActivity() {
 
   companion object {
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, isDarkTheme: Boolean) =
       Intent(context, DatingHomeActivity::class.java).apply { putExtra(DARK_THEME, isDarkTheme) }
   }
@@ -70,10 +71,7 @@ class DatingHomeActivity : ComponentActivity() {
 
 @SuppressLint("UnusedCrossfadeTargetStateParameter")
 @Composable
-fun DatingHomeContent(
-  navType: MutableState<DatingNavType>,
-  modifier: Modifier = Modifier,
-) {
+fun DatingHomeContent(navType: MutableState<DatingNavType>, modifier: Modifier = Modifier) {
   Crossfade(targetState = navType, modifier = modifier) {
     when (navType.value) {
       DatingNavType.PEOPLES -> DatingHomeScreen()
@@ -88,7 +86,7 @@ fun DatingBottomBar(navType: MutableState<DatingNavType>) {
   NavigationBar(
     containerColor = MaterialTheme.colorScheme.contentColorFor(purple),
     contentColor = purple,
-    tonalElevation = 4.dp
+    tonalElevation = 4.dp,
   ) {
     NavigationBarItem(
       icon = { Icon(imageVector = Icons.Filled.Style, contentDescription = null) },
@@ -126,7 +124,7 @@ fun DatingHomeAppbar(navType: MutableState<DatingNavType>) {
 enum class DatingNavType {
   PEOPLES,
   CHATS,
-  PROFILE
+  PROFILE,
 }
 
 @Preview(showBackground = true)

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/DatingChatItem.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/DatingChatItem.kt
@@ -23,25 +23,21 @@ fun DatingChatItem(album: Album) {
       ImageWithChatDot(
         imageId = album.imageId,
         modifier = Modifier.size(50.dp),
-        showDot = album.id % 3 == 0
+        showDot = album.id % 3 == 0,
       )
       Column(modifier = Modifier.weight(1f)) {
         Text(
           text = album.artist,
           modifier = Modifier.padding(horizontal = 8.dp),
-          style = typography.h6.copy(fontSize = 14.sp)
+          style = typography.h6.copy(fontSize = 14.sp),
         )
         Text(
           text = randomMessages[album.id - 1],
           modifier = Modifier.padding(horizontal = 8.dp),
-          style = typography.subtitle2
+          style = typography.subtitle2,
         )
       }
-      Text(
-        text = "${Random.nextInt(1, 60)} min",
-        color = purple,
-        style = typography.body2,
-      )
+      Text(text = "${Random.nextInt(1, 60)} min", color = purple, style = typography.body2)
     }
   }
 }

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/DatingChatScreen.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/DatingChatScreen.kt
@@ -19,7 +19,7 @@ val randomMessages =
     "Same here \uD83D\uDE18",
     "See ya tomorrow \uD83D\uDE00",
     "That's sad to hear \uD83D\uDE1E",
-    "Can we ? \uD83D\uDE0D\uD83D\uDE0D"
+    "Can we ? \uD83D\uDE0D\uD83D\uDE0D",
   )
 
 @Composable

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/MatchesImage.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/MatchesImage.kt
@@ -42,11 +42,11 @@ fun MatchesImage(imageId: Int) {
                 Brush.linearGradient(
                   colors = instagramGradient,
                   start = Offset(0f, 0f),
-                  end = Offset(100f, 100f)
-                )
-            )
+                  end = Offset(100f, 100f),
+                ),
+            ),
         ),
-    contentDescription = null
+    contentDescription = null,
   )
 }
 
@@ -58,13 +58,13 @@ fun ImageWithChatDot(imageId: Int, modifier: Modifier, showDot: Boolean = true) 
         painter = painterResource(id = imageId),
         contentDescription = null,
         contentScale = ContentScale.Crop,
-        modifier = modifier.clip(CircleShape)
+        modifier = modifier.clip(CircleShape),
       )
       Icon(
         imageVector = Icons.Default.Lens,
         contentDescription = null,
         tint = green500,
-        modifier = Modifier.size(14.dp).align(Alignment.BottomEnd)
+        modifier = Modifier.size(14.dp).align(Alignment.BottomEnd),
       )
     }
   } else {
@@ -72,7 +72,7 @@ fun ImageWithChatDot(imageId: Int, modifier: Modifier, showDot: Boolean = true) 
       painter = painterResource(id = imageId),
       contentDescription = null,
       contentScale = ContentScale.Crop,
-      modifier = modifier.clip(CircleShape)
+      modifier = modifier.clip(CircleShape),
     )
   }
 }

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/MatchesSections.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/chat/MatchesSections.kt
@@ -21,7 +21,7 @@ fun MatchSection() {
     text = "New matches",
     style = typography.h6.copy(fontSize = 16.sp),
     modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-    color = purple
+    color = purple,
   )
   LazyRow { items(items = matches, itemContent = { MatchesImage(imageId = it.imageId) }) }
   Spacer(modifier = Modifier.height(24.dp))

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/home/DatingHomeScreen.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/home/DatingHomeScreen.kt
@@ -79,7 +79,7 @@ fun DatingHomeScreen() {
                 listEmpty.value = true
               }
             }
-          }
+          },
         ) {
           CardContent(album)
         }
@@ -89,7 +89,7 @@ fun DatingHomeScreen() {
         modifier =
           Modifier.fillMaxWidth()
             .padding(top = cardHeight)
-            .alpha(animateFloatAsState(if (listEmpty.value) 0f else 1f).value)
+            .alpha(animateFloatAsState(if (listEmpty.value) 0f else 1f).value),
       ) {
         IconButton(
           onClick = {
@@ -99,13 +99,13 @@ fun DatingHomeScreen() {
             Modifier.padding(horizontal = 16.dp)
               .size(60.dp)
               .clip(CircleShape)
-              .background(MaterialTheme.colorScheme.background)
+              .background(MaterialTheme.colorScheme.background),
         ) {
           Icon(
             imageVector = Icons.Default.Cancel,
             tint = Color.Gray,
             contentDescription = null,
-            modifier = Modifier.size(36.dp)
+            modifier = Modifier.size(36.dp),
           )
         }
         IconButton(
@@ -116,13 +116,13 @@ fun DatingHomeScreen() {
             Modifier.padding(horizontal = 16.dp)
               .size(60.dp)
               .clip(CircleShape)
-              .background(MaterialTheme.colorScheme.background)
+              .background(MaterialTheme.colorScheme.background),
         ) {
           Icon(
             imageVector = Icons.Default.Favorite,
             contentDescription = null,
             tint = Color.Red,
-            modifier = Modifier.size(36.dp)
+            modifier = Modifier.size(36.dp),
           )
         }
       }
@@ -137,32 +137,32 @@ fun CardContent(album: Album) {
       painter = painterResource(album.imageId),
       contentScale = ContentScale.Crop,
       contentDescription = null,
-      modifier = Modifier.weight(1f)
+      modifier = Modifier.weight(1f),
     )
     Row(modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)) {
       Text(
         text = album.artist,
         style = typography.h6,
         modifier = Modifier.padding(end = 8.dp).weight(1f),
-        textAlign = TextAlign.Start
+        textAlign = TextAlign.Start,
       )
       Icon(
         imageVector = Icons.Outlined.Place,
         modifier = Modifier.padding(horizontal = 8.dp),
         tint = purple,
-        contentDescription = null
+        contentDescription = null,
       )
       Text(text = "${Random.nextInt(1, 15)} km", style = typography.body2, color = purple)
     }
     Text(
       text = "Age: ${Random.nextInt(21, 30)}, Casually browsing..",
       style = typography.subtitle2,
-      modifier = Modifier.padding(bottom = 4.dp, start = 16.dp, end = 16.dp)
+      modifier = Modifier.padding(bottom = 4.dp, start = 16.dp, end = 16.dp),
     )
     Text(
       text = "Miami, Florida",
       style = typography.subtitle2,
-      modifier = Modifier.padding(bottom = 16.dp, start = 16.dp, end = 16.dp)
+      modifier = Modifier.padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
     )
   }
 }

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/home/DraggableCard.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/home/DraggableCard.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 
 enum class SwipeResult {
   ACCEPTED,
-  REJECTED
+  REJECTED,
 }
 
 @Composable
@@ -30,7 +30,7 @@ fun DraggableCard(
   item: Any,
   modifier: Modifier = Modifier,
   onSwiped: (Any, Any) -> Unit,
-  content: @Composable () -> Unit
+  content: @Composable () -> Unit,
 ) {
   val screenWidth = LocalConfiguration.current.screenWidthDp.dp
   val swipeXLeft = -(screenWidth.value * 3.2).toFloat()
@@ -53,7 +53,7 @@ fun DraggableCard(
             translationY = swipeY.value,
             rotationZ = rotationFraction,
           )
-          .clip(RoundedCornerShape(16.dp))
+          .clip(RoundedCornerShape(16.dp)),
     ) {
       content()
     }
@@ -68,7 +68,7 @@ fun Modifier.dragContent(
   swipeX: Animatable<Float, AnimationVector1D>,
   swipeY: Animatable<Float, AnimationVector1D>,
   maxX: Float,
-  onSwiped: (Any, Any) -> Unit
+  onSwiped: (Any, Any) -> Unit,
 ): Modifier = composed {
   val coroutineScope = rememberCoroutineScope()
   pointerInput(Unit) {
@@ -95,7 +95,7 @@ fun Modifier.dragContent(
             }
           }
         }
-      }
+      },
     ) { change, dragAmount ->
       change.consumePositionChange()
       coroutineScope.apply {

--- a/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/profile/ProfileScreen.kt
+++ b/demos/datingapp/src/main/java/com/guru/composecookbook/datingapp/components/profile/ProfileScreen.kt
@@ -13,7 +13,7 @@ import com.guru.composecookbook.comingsoon.ComingSoon
 fun ProfileScreen() {
   LazyColumn(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     item { ComingSoon() }
   }

--- a/demos/gmail/build.gradle.kts
+++ b/demos/gmail/build.gradle.kts
@@ -2,21 +2,17 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.gmail"
-}
+android { namespace = "com.guru.composecookbook.gmail" }
 
 dependencies {
-    implementation(project(":components:fab"))
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":components:fab"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/create/CreateMessageBody.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/create/CreateMessageBody.kt
@@ -21,20 +21,18 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun CreateMessageBody(
-  modifier: Modifier = Modifier,
-) {
+fun CreateMessageBody(modifier: Modifier = Modifier) {
   Column(modifier = modifier) {
     Row {
       Text(text = "From", modifier = Modifier.padding(16.dp).align(Alignment.CenterVertically))
       Text(
         text = "subash@gmail.com",
-        modifier = Modifier.weight(1f).padding(vertical = 16.dp).align(Alignment.CenterVertically)
+        modifier = Modifier.weight(1f).padding(vertical = 16.dp).align(Alignment.CenterVertically),
       )
       Icon(
         imageVector = Icons.Outlined.KeyboardArrowDown,
         contentDescription = null,
-        modifier = Modifier.align(Alignment.CenterVertically).padding(16.dp)
+        modifier = Modifier.align(Alignment.CenterVertically).padding(16.dp),
       )
     }
     Divider(color = Color.LightGray, thickness = 0.5.dp)
@@ -45,12 +43,12 @@ fun CreateMessageBody(
         onValueChange = {},
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
         keyboardActions = KeyboardActions(onDone = {}),
-        modifier = Modifier.weight(1f).padding(vertical = 16.dp).align(Alignment.CenterVertically)
+        modifier = Modifier.weight(1f).padding(vertical = 16.dp).align(Alignment.CenterVertically),
       )
       Icon(
         imageVector = Icons.Outlined.KeyboardArrowDown,
         contentDescription = null,
-        modifier = Modifier.align(Alignment.CenterVertically).padding(16.dp)
+        modifier = Modifier.align(Alignment.CenterVertically).padding(16.dp),
       )
     }
 
@@ -60,7 +58,7 @@ fun CreateMessageBody(
       onValueChange = {},
       keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
       keyboardActions = KeyboardActions(onDone = {}),
-      modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp, horizontal = 16.dp)
+      modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp, horizontal = 16.dp),
     )
     Divider(color = Color.LightGray, thickness = 0.5.dp)
     BasicTextField(
@@ -68,7 +66,7 @@ fun CreateMessageBody(
       onValueChange = {},
       keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
       keyboardActions = KeyboardActions(onDone = {}),
-      modifier = Modifier.fillMaxWidth().weight(1f).padding(vertical = 16.dp, horizontal = 16.dp)
+      modifier = Modifier.fillMaxWidth().weight(1f).padding(vertical = 16.dp, horizontal = 16.dp),
     )
   }
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/create/CreateMessageMoreActionPopupMenu.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/create/CreateMessageMoreActionPopupMenu.kt
@@ -20,21 +20,21 @@ fun CreateMessageMoreActionPopupMenu() {
     onDismissRequest = { expanded.value = false },
     // toggle = iconButton,
     offset = DpOffset((-32).dp, (-32).dp),
-    modifier = Modifier.background(MaterialTheme.colors.surface)
+    modifier = Modifier.background(MaterialTheme.colors.surface),
   ) {
-    DropdownMenuItem(onClick = { /* Handle refresh! */}) { Text("Schedule send") }
-    DropdownMenuItem(onClick = { /* Handle settings! */}) { Text("Add from Contacts") }
+    DropdownMenuItem(onClick = { /* Handle refresh! */ }) { Text("Schedule send") }
+    DropdownMenuItem(onClick = { /* Handle settings! */ }) { Text("Add from Contacts") }
 
-    DropdownMenuItem(onClick = { /* Handle send feedback! */}) { Text("Confidential mode") }
+    DropdownMenuItem(onClick = { /* Handle send feedback! */ }) { Text("Confidential mode") }
 
-    DropdownMenuItem(onClick = { /* Handle send feedback! */}, enabled = false) {
+    DropdownMenuItem(onClick = { /* Handle send feedback! */ }, enabled = false) {
       Text("Save draft")
     }
 
-    DropdownMenuItem(onClick = { /* Handle send feedback! */}) { Text("Discard") }
+    DropdownMenuItem(onClick = { /* Handle send feedback! */ }) { Text("Discard") }
 
-    DropdownMenuItem(onClick = { /* Handle send feedback! */}) { Text("Settings") }
+    DropdownMenuItem(onClick = { /* Handle send feedback! */ }) { Text("Settings") }
 
-    DropdownMenuItem(onClick = { /* Handle send feedback! */}) { Text("Help and feedback") }
+    DropdownMenuItem(onClick = { /* Handle send feedback! */ }) { Text("Help and feedback") }
   }
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/create/CreateMessageScreen.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/create/CreateMessageScreen.kt
@@ -29,7 +29,7 @@ fun CreateMessageScreen(navController: NavHostController) {
           IconButton(onClick = { navController.popBackStack() }) {
             Icon(
               imageVector = Icons.Outlined.ArrowBack,
-              contentDescription = stringResource(id = R.string.cd_back)
+              contentDescription = stringResource(id = R.string.cd_back),
             )
           }
         },
@@ -41,13 +41,9 @@ fun CreateMessageScreen(navController: NavHostController) {
             Icon(imageVector = Icons.Outlined.Send, contentDescription = null)
           }
           CreateMessageMoreActionPopupMenu()
-        }
+        },
       )
     },
-    content = { paddingValues ->
-      CreateMessageBody(
-        modifier = Modifier.padding(paddingValues),
-      )
-    },
+    content = { paddingValues -> CreateMessageBody(modifier = Modifier.padding(paddingValues)) },
   )
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/details/MessageDetailBody.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/details/MessageDetailBody.kt
@@ -52,12 +52,12 @@ fun MessageDetailBody(modifier: Modifier = Modifier) {
         Text(
           text = "Sudip Kafle and others share theier thougs on Linkedin",
           fontSize = 20.sp,
-          modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 16.dp).weight(1f)
+          modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 16.dp).weight(1f),
         )
         IconButton(onClick = { isFavourite.value = !isFavourite.value }) {
           Icon(
             imageVector = if (isFavourite.value) Icons.Outlined.Star else Icons.Outlined.StarBorder,
-            contentDescription = ""
+            contentDescription = "",
           )
         }
       }
@@ -68,7 +68,7 @@ fun MessageDetailBody(modifier: Modifier = Modifier) {
         Image(
           painter = painterResource(id = R.drawable.p3),
           contentDescription = null,
-          modifier = Modifier.padding(horizontal = 8.dp).size(32.dp).clip(CircleShape)
+          modifier = Modifier.padding(horizontal = 8.dp).size(32.dp).clip(CircleShape),
         )
 
         Column(
@@ -80,7 +80,7 @@ fun MessageDetailBody(modifier: Modifier = Modifier) {
               text = "26 Oct",
               fontSize = 12.sp,
               textAlign = TextAlign.Center,
-              modifier = Modifier.padding(start = 4.dp).align(Alignment.CenterVertically)
+              modifier = Modifier.padding(start = 4.dp).align(Alignment.CenterVertically),
             )
           }
 
@@ -135,7 +135,7 @@ fun MessageDetailBody(modifier: Modifier = Modifier) {
         factory = {
           WebView(it).apply { loadDataWithBaseURL(null, sampleMessage, "text/html", "UTF-8", null) }
         },
-        modifier = Modifier.wrapContentHeight()
+        modifier = Modifier.wrapContentHeight(),
       )
     }
 
@@ -144,17 +144,17 @@ fun MessageDetailBody(modifier: Modifier = Modifier) {
         ReplyTypeAction(
           asset = Icons.AutoMirrored.Outlined.Undo,
           text = "Reply",
-          modifier = Modifier.weight(1f)
+          modifier = Modifier.weight(1f),
         )
         ReplyTypeAction(
           asset = Icons.AutoMirrored.Outlined.Reply,
           text = "Reply All",
-          modifier = Modifier.weight(1f)
+          modifier = Modifier.weight(1f),
         )
         ReplyTypeAction(
           asset = Icons.AutoMirrored.Outlined.Redo,
           text = "Forward",
-          modifier = Modifier.weight(1f)
+          modifier = Modifier.weight(1f),
         )
       }
     }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/details/MessageDetailScreen.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/details/MessageDetailScreen.kt
@@ -29,7 +29,7 @@ fun MessageDetailScreen(navController: NavHostController) {
           IconButton(onClick = { navController.popBackStack() }) {
             Icon(
               imageVector = Icons.Outlined.ArrowBack,
-              contentDescription = stringResource(id = R.string.cd_back)
+              contentDescription = stringResource(id = R.string.cd_back),
             )
           }
         },
@@ -37,7 +37,7 @@ fun MessageDetailScreen(navController: NavHostController) {
           IconButton(onClick = {}) {
             Icon(
               imageVector = Icons.Outlined.Archive,
-              contentDescription = stringResource(id = R.string.cd_back)
+              contentDescription = stringResource(id = R.string.cd_back),
             )
           }
           IconButton(onClick = {}) {
@@ -46,13 +46,9 @@ fun MessageDetailScreen(navController: NavHostController) {
           IconButton(onClick = {}) {
             Icon(imageVector = Icons.Outlined.Mail, contentDescription = null)
           }
-        }
+        },
       )
     },
-    content = { paddingValues ->
-      MessageDetailBody(
-        modifier = Modifier.padding(paddingValues),
-      )
-    }
+    content = { paddingValues -> MessageDetailBody(modifier = Modifier.padding(paddingValues)) },
   )
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailDrawer.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailDrawer.kt
@@ -44,7 +44,7 @@ fun GmailDrawer(modifier: Modifier = Modifier) {
         text = "Gmail",
         color = Color.Red,
         fontSize = 24.sp,
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp),
       )
     }
 
@@ -85,7 +85,7 @@ fun DrawerItem(icon: ImageVector, title: String, msgCount: String = "") {
       fontFamily = FontFamily.SansSerif,
       fontWeight = FontWeight.SemiBold,
       fontSize = 14.sp,
-      textAlign = TextAlign.Start
+      textAlign = TextAlign.Start,
     )
 
     if (msgCount.isNotEmpty()) {
@@ -93,7 +93,7 @@ fun DrawerItem(icon: ImageVector, title: String, msgCount: String = "") {
         modifier = Modifier.align(Alignment.CenterVertically).padding(16.dp),
         text = msgCount,
         style = MaterialTheme.typography.caption,
-        textAlign = TextAlign.Start
+        textAlign = TextAlign.Start,
       )
     }
   }
@@ -107,6 +107,6 @@ fun DrawerCategory(title: String) {
     letterSpacing = 0.7.sp,
     color = MaterialTheme.colors.onBackground,
     fontSize = 12.sp,
-    modifier = Modifier.padding(16.dp)
+    modifier = Modifier.padding(16.dp),
   )
 }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailHome.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailHome.kt
@@ -133,7 +133,7 @@ fun IconWithBadge(badge: Int, icon: ImageVector, modifier: Modifier = Modifier) 
     Icon(
       imageVector = icon,
       modifier = modifier.align(Alignment.BottomCenter),
-      contentDescription = null
+      contentDescription = null,
     )
 
     if (badge != 0) {
@@ -147,7 +147,7 @@ fun IconWithBadge(badge: Int, icon: ImageVector, modifier: Modifier = Modifier) 
             .clip(CircleShape)
             .background(Color.Red)
             .align(Alignment.TopEnd)
-            .size(16.dp)
+            .size(16.dp),
       )
     }
   }
@@ -160,17 +160,17 @@ fun GmailFloatingActionButton(navController: NavHostController, expandState: Boo
     onClick = { navController.navigate("create") },
     modifier = Modifier.padding(16.dp).height(48.dp).widthIn(min = 48.dp),
     backgroundColor = MaterialTheme.colors.surface,
-    contentColor = MaterialTheme.colors.primary
+    contentColor = MaterialTheme.colors.primary,
   ) {
     AnimatingFabContent(
       icon = {
         Icon(
           imageVector = Icons.Outlined.Edit,
-          contentDescription = stringResource(id = R.string.cd_create_new_email)
+          contentDescription = stringResource(id = R.string.cd_create_new_email),
         )
       },
       text = { Text(text = "Compose", modifier = Modifier.padding(end = 8.dp)) },
-      extended = expandState
+      extended = expandState,
     )
   }
 }
@@ -264,7 +264,7 @@ fun UserEmailDialog(showUserDialog: MutableState<Boolean>) {
         modifier = Modifier,
         shape = MaterialTheme.shapes.medium,
         color = background,
-        contentColor = MaterialTheme.colors.onSurface
+        contentColor = MaterialTheme.colors.onSurface,
       ) {
         Column {
           Row(verticalAlignment = Alignment.CenterVertically) {
@@ -276,7 +276,7 @@ fun UserEmailDialog(showUserDialog: MutableState<Boolean>) {
               text = "Google",
               textAlign = TextAlign.Center,
               fontSize = 24.sp,
-              modifier = Modifier.fillMaxWidth()
+              modifier = Modifier.fillMaxWidth(),
             )
           }
 
@@ -292,7 +292,7 @@ fun UserEmailDialog(showUserDialog: MutableState<Boolean>) {
                 .clip(RoundedCornerShape(16.dp))
                 .clickable(onClick = {})
                 .padding(horizontal = 12.dp, vertical = 8.dp)
-                .align(Alignment.CenterHorizontally)
+                .align(Alignment.CenterHorizontally),
           )
 
           Divider(thickness = 1.dp, modifier = Modifier.fillMaxWidth())
@@ -301,49 +301,49 @@ fun UserEmailDialog(showUserDialog: MutableState<Boolean>) {
             imageId = R.drawable.p2,
             name = "Subash ",
             email = "aryal.subash@yahoo.com",
-            badgeCount = 39
+            badgeCount = 39,
           )
           GmailUserEmail(
             imageId = R.drawable.p2,
             name = "Subash Zi ",
             email = "subashz@gmail.com",
-            badgeCount = 10
+            badgeCount = 10,
           )
 
           Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
           ) {
             Icon(
               imageVector = Icons.Default.PersonAdd,
               tint = MaterialTheme.colors.onSurface,
               modifier = Modifier.padding(8.dp),
-              contentDescription = null
+              contentDescription = null,
             )
 
             Text(
               text = "Add another account",
               fontSize = 14.sp,
               color = MaterialTheme.colors.onSurface,
-              modifier = Modifier.padding(start = 8.dp)
+              modifier = Modifier.padding(start = 8.dp),
             )
           }
 
           Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
           ) {
             Icon(
               imageVector = Icons.Default.AccountCircle,
               tint = MaterialTheme.colors.onSurface,
               modifier = Modifier.padding(8.dp),
-              contentDescription = null
+              contentDescription = null,
             )
             Text(
               text = "Manage accounts on this device",
               fontSize = 14.sp,
               color = MaterialTheme.colors.onSurface,
-              modifier = Modifier.padding(start = 8.dp)
+              modifier = Modifier.padding(start = 8.dp),
             )
           }
 
@@ -351,20 +351,20 @@ fun UserEmailDialog(showUserDialog: MutableState<Boolean>) {
 
           Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(vertical = 8.dp).align(Alignment.CenterHorizontally)
+            modifier = Modifier.padding(vertical = 8.dp).align(Alignment.CenterHorizontally),
           ) {
             Text(
               text = "Privacy Policy",
               fontSize = 12.sp,
               modifier =
-                Modifier.clip(RoundedCornerShape(8.dp)).clickable(onClick = {}).padding(8.dp)
+                Modifier.clip(RoundedCornerShape(8.dp)).clickable(onClick = {}).padding(8.dp),
             )
             Text(text = "•")
             Text(
               text = "Terms of service",
               fontSize = 12.sp,
               modifier =
-                Modifier.clip(RoundedCornerShape(8.dp)).clickable(onClick = {}).padding(8.dp)
+                Modifier.clip(RoundedCornerShape(8.dp)).clickable(onClick = {}).padding(8.dp),
             )
           }
         }
@@ -380,7 +380,7 @@ fun GmailUserEmail(imageId: Int, name: String, email: String, badgeCount: Int) {
     Image(
       painter = painterResource(id = imageId),
       contentDescription = null,
-      modifier = Modifier.size(32.dp).clip(CircleShape).clickable(onClick = {})
+      modifier = Modifier.size(32.dp).clip(CircleShape).clickable(onClick = {}),
     )
 
     Column(modifier = Modifier.weight(1f).padding(start = 16.dp)) {

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailListItem.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/GmailListItem.kt
@@ -60,7 +60,7 @@ fun GmailListItem(item: Tweet, clickListener: (Tweet) -> Unit) {
         Modifier.size(50.dp).clip(CircleShape).constrainAs(image) {
           linkTo(start = parent.start, end = title.start)
           top.linkTo(title.top)
-        }
+        },
     )
     Text(
       text = item.author,
@@ -69,7 +69,7 @@ fun GmailListItem(item: Tweet, clickListener: (Tweet) -> Unit) {
         Modifier.constrainAs(title) {
           start.linkTo(image.end, 16.dp)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = "5 sept",
@@ -78,7 +78,7 @@ fun GmailListItem(item: Tweet, clickListener: (Tweet) -> Unit) {
         Modifier.constrainAs(time) {
           end.linkTo(parent.end, margin = 8.dp)
           top.linkTo(title.top)
-        }
+        },
     )
     Text(
       text = item.source,
@@ -87,7 +87,7 @@ fun GmailListItem(item: Tweet, clickListener: (Tweet) -> Unit) {
         Modifier.constrainAs(subtitle) {
           start.linkTo(image.end, 16.dp)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = item.text,
@@ -98,23 +98,20 @@ fun GmailListItem(item: Tweet, clickListener: (Tweet) -> Unit) {
             linkTo(start = title.start, end = starButton.start)
             width = Dimension.fillToConstraints
           }
-          .alpha(0.6f)
+          .alpha(0.6f),
     )
     IconButton(
       onClick = { stared = !stared },
       modifier =
         Modifier.constrainAs(starButton) {
-          linkTo(
-            top = source.top,
-            bottom = source.bottom,
-          )
+          linkTo(top = source.top, bottom = source.bottom)
           linkTo(start = source.end, end = parent.end)
-        }
+        },
     ) {
       Icon(
         imageVector = if (stared) Icons.Default.Star else Icons.Default.StarBorder,
         contentDescription = null,
-        tint = if (stared) Color.Yellow else MaterialTheme.colorScheme.onSurface
+        tint = if (stared) Color.Yellow else MaterialTheme.colorScheme.onSurface,
       )
     }
   }
@@ -127,14 +124,14 @@ fun GmailListActionItems(modifier: Modifier) {
       Icon(
         imageVector = Icons.Default.Delete,
         tint = MaterialTheme.colorScheme.onPrimary,
-        contentDescription = null
+        contentDescription = null,
       )
     }
     IconButton(onClick = {}) {
       Icon(
         imageVector = Icons.Default.AccountBox,
         tint = MaterialTheme.colorScheme.onPrimary,
-        contentDescription = null
+        contentDescription = null,
       )
     }
   }

--- a/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/SearchLayout.kt
+++ b/demos/gmail/src/main/java/com/guru/composecookbook/gmail/ui/home/SearchLayout.kt
@@ -45,7 +45,7 @@ fun SearchLayout(
   offset: Int,
   drawerState: DrawerState,
   showUserDialog: MutableState<Boolean>,
-  onCreateNewEmailClickListener: () -> Unit
+  onCreateNewEmailClickListener: () -> Unit,
 ) {
 
   val searchLayoutHeightDp = 70.dp
@@ -57,15 +57,13 @@ fun SearchLayout(
         .height(searchLayoutHeightDp)
         .padding(8.dp)
         .shadow(8.dp, shape = RoundedCornerShape(8.dp), clip = false)
-        .background(background, shape = RoundedCornerShape(8.dp))
+        .background(background, shape = RoundedCornerShape(8.dp)),
   ) {
     val coroutineScope = rememberCoroutineScope()
-    IconButton(
-      onClick = { coroutineScope.launch { drawerState.open() } },
-    ) {
+    IconButton(onClick = { coroutineScope.launch { drawerState.open() } }) {
       Icon(
         imageVector = Icons.Outlined.Menu,
-        contentDescription = stringResource(id = R.string.cd_gmail_menu)
+        contentDescription = stringResource(id = R.string.cd_gmail_menu),
       )
     }
 
@@ -79,21 +77,19 @@ fun SearchLayout(
           backgroundColor = background,
           cursorColor = MaterialTheme.colors.onSurface,
           focusedIndicatorColor = background,
-          disabledIndicatorColor = background
+          disabledIndicatorColor = background,
         ),
-      textStyle = typography.body2
+      textStyle = typography.body2,
     )
 
     val accessibilityManager =
       LocalContext.current.getSystemService(Context.ACCESSIBILITY_SERVICE)
         as android.view.accessibility.AccessibilityManager
     if (accessibilityManager.isEnabled && accessibilityManager.isTouchExplorationEnabled) {
-      IconButton(
-        onClick = { onCreateNewEmailClickListener.invoke() },
-      ) {
+      IconButton(onClick = { onCreateNewEmailClickListener.invoke() }) {
         Icon(
           imageVector = Icons.Outlined.Edit,
-          contentDescription = stringResource(id = R.string.cd_create_new_email)
+          contentDescription = stringResource(id = R.string.cd_create_new_email),
         )
       }
     }
@@ -105,7 +101,7 @@ fun SearchLayout(
         Modifier.padding(horizontal = 8.dp)
           .size(32.dp)
           .clip(CircleShape)
-          .clickable(onClick = { showUserDialog.value = true })
+          .clickable(onClick = { showUserDialog.value = true }),
     )
   }
 }

--- a/demos/instagram/build.gradle.kts
+++ b/demos/instagram/build.gradle.kts
@@ -3,21 +3,17 @@ import com.guru.composecookbook.build.dependencies.addComposeThirdPartyDependenc
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.instagram"
-}
+android { namespace = "com.guru.composecookbook.instagram" }
 
 dependencies {
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/InstagramActivity.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/InstagramActivity.kt
@@ -28,7 +28,7 @@ class InstagramActivity : ComponentActivity() {
           onCommentsClicked = {},
           onSendClicked = {},
           onProfileClicked = {},
-          onMessagingClicked = {}
+          onMessagingClicked = {},
         )
       }
     }
@@ -50,7 +50,7 @@ fun DefaultPreview4() {
       onCommentsClicked = {},
       onSendClicked = {},
       onProfileClicked = {},
-      onMessagingClicked = {}
+      onMessagingClicked = {},
     )
   }
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/InstagramHome.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/InstagramHome.kt
@@ -39,7 +39,7 @@ fun InstagramHome(
   onCommentsClicked: () -> Unit,
   onSendClicked: () -> Unit,
   onProfileClicked: () -> Unit,
-  onMessagingClicked: () -> Unit
+  onMessagingClicked: () -> Unit,
 ) {
   var showStory = remember { mutableStateOf(false) }
 
@@ -55,7 +55,7 @@ fun InstagramHome(
             IconButton(onClick = {}) {
               Icon(
                 painter = painterResource(id = R.drawable.ic_instagram),
-                contentDescription = null
+                contentDescription = null,
               )
             }
           },
@@ -66,7 +66,7 @@ fun InstagramHome(
                 contentDescription = "Go to messaging screen",
               )
             }
-          }
+          },
         )
       },
       content = { paddingValues ->
@@ -77,23 +77,23 @@ fun InstagramHome(
               onProfileClicked = {
                 showStory.value = true
                 onProfileClicked.invoke()
-              }
+              },
             )
             Divider()
             PostList(
               posts = posts,
               onLikeClicked = onLikeClicked,
               onCommentsClicked = onCommentsClicked,
-              onSendClicked = onSendClicked
+              onSendClicked = onSendClicked,
             )
           }
         }
-      }
+      },
     )
     AnimatedVisibility(
       visible = showStory.value,
       enter = expandVertically() + fadeIn(),
-      exit = shrinkVertically() + fadeOut()
+      exit = shrinkVertically() + fadeOut(),
     ) {
       StoryPopup(imageIds = DemoDataProvider.itemList.take(5)) { showStory.value = false }
     }
@@ -110,6 +110,6 @@ fun PreviewInstagramHome() {
     onCommentsClicked = {},
     onSendClicked = {},
     onProfileClicked = {},
-    onMessagingClicked = {}
+    onMessagingClicked = {},
   )
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostImage.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostImage.kt
@@ -16,13 +16,13 @@ import com.guru.composecookbook.data.DemoDataProvider
 fun PostImage(
   @DrawableRes imageId: Int,
   contentDescription: String?,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Image(
     painter = painterResource(id = imageId),
     modifier = modifier.fillMaxWidth().height(450.dp),
     contentDescription = contentDescription,
-    contentScale = ContentScale.Crop
+    contentScale = ContentScale.Crop,
   )
 }
 
@@ -31,6 +31,6 @@ fun PostImage(
 fun PostImagePreview() {
   PostImage(
     imageId = DemoDataProvider.tweetList.first { it.tweetImageId != 0 }.tweetImageId,
-    contentDescription = null
+    contentDescription = null,
   )
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostInteractionBar.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostInteractionBar.kt
@@ -16,16 +16,13 @@ fun PostInteractionBar(
   onLikeClicked: () -> Unit,
   onCommentsClicked: () -> Unit,
   onSendClicked: () -> Unit,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Row(modifier = modifier) {
     IconToggleButton(checked = isLiked, onCheckedChange = { onLikeClicked() }) {
       val icon = if (isLiked) FaIcons.Heart else FaIcons.HeartRegular
       val tint = if (isLiked) Color.Red else MaterialTheme.colorScheme.onPrimary
-      FaIcon(
-        faIcon = icon,
-        tint = tint,
-      )
+      FaIcon(faIcon = icon, tint = tint)
     }
     IconToggleButton(checked = false, onCheckedChange = { onCommentsClicked() }) {
       FaIcon(faIcon = FaIcons.CommentAltRegular, tint = MaterialTheme.colorScheme.onPrimary)

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostItem.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostItem.kt
@@ -27,7 +27,7 @@ fun PostItem(
   onLikeClicked: () -> Unit,
   onCommentsClicked: () -> Unit,
   onSendClicked: () -> Unit,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Column(modifier = modifier.fillMaxWidth().padding(8.dp)) {
     ProfileSection(
@@ -36,36 +36,36 @@ fun PostItem(
       size = ProfileSectionSizes.medium(),
       iconRight = {
         Icon(imageVector = Icons.Default.MoreVert, contentDescription = "See more options")
-      }
+      },
     )
     PostImage(
       imageId = post.tweetImageId,
       contentDescription = post.text,
-      modifier = Modifier.padding(top = 8.dp)
+      modifier = Modifier.padding(top = 8.dp),
     )
     PostInteractionBar(
       isLiked = isLiked,
       onLikeClicked = onLikeClicked,
       onCommentsClicked = onCommentsClicked,
-      onSendClicked = onSendClicked
+      onSendClicked = onSendClicked,
     )
     ProfileSection(
       firstImageId = post.authorImageId,
       text =
-        "Liked by ${DemoDataProvider.tweet.author} and ${DemoDataProvider.tweet.likesCount} others"
+        "Liked by ${DemoDataProvider.tweet.author} and ${DemoDataProvider.tweet.likesCount} others",
     )
     CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
       Text(
         text = "View all ${post.commentsCount} comments",
         style = MaterialTheme.typography.caption,
         modifier = Modifier.padding(top = 4.dp),
-        color = MaterialTheme.colors.onSurface.copy(alpha = LocalContentAlpha.current)
+        color = MaterialTheme.colors.onSurface.copy(alpha = LocalContentAlpha.current),
       )
       Text(
         text = "${post.time} ago",
         style = MaterialTheme.typography.caption,
         modifier = Modifier.padding(top = 4.dp),
-        color = MaterialTheme.colors.onSurface.copy(alpha = LocalContentAlpha.current)
+        color = MaterialTheme.colors.onSurface.copy(alpha = LocalContentAlpha.current),
       )
     }
   }
@@ -79,6 +79,6 @@ fun PostItemPreview() {
     isLiked = true,
     onLikeClicked = {},
     onCommentsClicked = {},
-    onSendClicked = {}
+    onSendClicked = {},
   )
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostList.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/posts/PostList.kt
@@ -22,7 +22,7 @@ fun PostList(
         isLiked = Random.nextBoolean(),
         onLikeClicked = onLikeClicked,
         onCommentsClicked = onCommentsClicked,
-        onSendClicked = onSendClicked
+        onSendClicked = onSendClicked,
       )
     }
   }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/profile/Profile.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/profile/Profile.kt
@@ -26,7 +26,7 @@ fun ProfilePicture(
     painter = painterResource(id = imageId),
     modifier = modifier.size(size).clip(CircleShape),
     contentDescription = contentDescription,
-    contentScale = ContentScale.Crop
+    contentScale = ContentScale.Crop,
   )
 }
 
@@ -43,12 +43,12 @@ fun ProfilePicturePreview() {
     ProfilePicture(
       imageId = DemoDataProvider.tweetList.first().authorImageId,
       contentDescription = "Profile picture",
-      size = ProfileSizes.small
+      size = ProfileSizes.small,
     )
     ProfilePicture(
       imageId = DemoDataProvider.tweetList.first().authorImageId,
       contentDescription = "Profile picture",
-      size = ProfileSizes.medium
+      size = ProfileSizes.medium,
     )
   }
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/profile/ProfileSection.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/profile/ProfileSection.kt
@@ -24,7 +24,7 @@ fun ProfileSection(
   text: String,
   modifier: Modifier = Modifier,
   iconRight: @Composable () -> Unit = {},
-  size: ProfileSectionSize = ProfileSectionSizes.small()
+  size: ProfileSectionSize = ProfileSectionSizes.small(),
 ) {
   Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
     ProfilePicture(imageId = firstImageId, contentDescription = null, size = size.profileIconSize)
@@ -32,7 +32,7 @@ fun ProfileSection(
       text = text,
       style = size.textStyle,
       color = MaterialTheme.colors.onBackground,
-      modifier = Modifier.weight(1f).padding(start = 8.dp)
+      modifier = Modifier.weight(1f).padding(start = 8.dp),
     )
     iconRight()
   }
@@ -53,7 +53,7 @@ fun ProfileInfoPreview() {
     firstImageId = DemoDataProvider.tweetList.first().authorImageId,
     text = DemoDataProvider.tweetList.first().author,
     size = ProfileSectionSizes.medium(),
-    iconRight = { Icon(imageVector = Icons.Default.MoreVert, contentDescription = null) }
+    iconRight = { Icon(imageVector = Icons.Default.MoreVert, contentDescription = null) },
   )
 }
 
@@ -63,6 +63,6 @@ fun LikesSectionPreview() {
   val tweet = DemoDataProvider.tweetList.first()
   ProfileSection(
     firstImageId = tweet.authorImageId,
-    text = "Liked by ${tweet.author} and ${tweet.likesCount} others"
+    text = "Liked by ${tweet.author} and ${tweet.likesCount} others",
   )
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/stories/StoryItem.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/stories/StoryItem.kt
@@ -44,7 +44,7 @@ fun StoryItem(
       Brush.linearGradient(
         colors = instagramGradient,
         start = Offset(x = 0f, y = 0f),
-        end = Offset(x = 100f, y = 100f)
+        end = Offset(x = 100f, y = 100f),
       )
     }
   Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
@@ -55,15 +55,15 @@ fun StoryItem(
       modifier =
         Modifier.border(
             shape = CircleShape,
-            border = BorderStroke(width = 3.dp, brush = borderColor)
+            border = BorderStroke(width = 3.dp, brush = borderColor),
           )
           .clickable(
             interactionSource = interactionSource,
             indication = rememberRipple(bounded = false, radius = ProfileSizes.large / 2),
             enabled = true,
             onClickLabel = null,
-            onClick = onClick
-          )
+            onClick = onClick,
+          ),
     )
     Text(text = profileName, style = textStyle, textAlign = TextAlign.Center)
   }
@@ -76,7 +76,7 @@ fun StoryItemPreview() {
     profileImageId = DemoDataProvider.tweet.authorImageId,
     profileName = DemoDataProvider.tweet.author,
     isMe = false,
-    onClick = {}
+    onClick = {},
   )
 }
 
@@ -87,6 +87,6 @@ fun StoryItemMePreview() {
     profileImageId = DemoDataProvider.tweet.authorImageId,
     profileName = DemoDataProvider.tweet.author,
     isMe = true,
-    onClick = {}
+    onClick = {},
   )
 }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/stories/StoryList.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/stories/StoryList.kt
@@ -15,14 +15,14 @@ fun StoryList(profiles: List<Tweet>, onProfileClicked: () -> Unit, modifier: Mod
   LazyRow(
     modifier = modifier.padding(top = 8.dp, bottom = 8.dp),
     horizontalArrangement = Arrangement.spacedBy(8.dp),
-    contentPadding = PaddingValues(horizontal = 8.dp)
+    contentPadding = PaddingValues(horizontal = 8.dp),
   ) {
     items(profiles) {
       StoryItem(
         profileImageId = it.authorImageId,
         profileName = it.author,
         isMe = it.id == 1,
-        onClick = onProfileClicked
+        onClick = onProfileClicked,
       )
     }
   }

--- a/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/stories/StoryPopup.kt
+++ b/demos/instagram/src/main/java/com/guru/composecookbook/instagram/components/stories/StoryPopup.kt
@@ -65,7 +65,7 @@ fun StoryPopup(imageIds: List<Item>, closePopup: () -> Unit) {
     Brush.linearGradient(
       colors = instagramGradient,
       start = Offset(x = 0f, y = 0f),
-      end = Offset(x = 100f, y = 100f)
+      end = Offset(x = 100f, y = 100f),
     )
 
   BackHandler() { closePopup.invoke() }
@@ -104,7 +104,7 @@ fun StoryPopup(imageIds: List<Item>, closePopup: () -> Unit) {
       painter = painterResource(id = imageIds[currentStoryCount].imageId),
       modifier = Modifier.fillMaxSize(),
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
       LaunchedEffect(currentStoryCount, storyPaused) { // (2)
@@ -116,8 +116,8 @@ fun StoryPopup(imageIds: List<Item>, closePopup: () -> Unit) {
             animationSpec =
               tween(
                 durationMillis = (5000 * (1f - percent.value)).toInt(), // (3)
-                easing = LinearEasing
-              )
+                easing = LinearEasing,
+              ),
           )
           if (storySize - 1 > currentStoryCount) {
             percent.snapTo(0f)
@@ -138,13 +138,13 @@ fun StoryPopup(imageIds: List<Item>, closePopup: () -> Unit) {
           LinearProgressIndicator(
             modifier = Modifier.weight(1f).padding(horizontal = 4.dp),
             progress = progress,
-            color = MaterialTheme.colors.onBackground
+            color = MaterialTheme.colors.onBackground,
           )
         }
       }
       Row(
         modifier = Modifier.fillMaxWidth().padding(8.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
       ) {
         ProfilePicture(
           imageId = imageIds[0].imageId,
@@ -153,19 +153,19 @@ fun StoryPopup(imageIds: List<Item>, closePopup: () -> Unit) {
           modifier =
             Modifier.border(
               shape = CircleShape,
-              border = BorderStroke(width = 3.dp, brush = brushGradient)
-            )
+              border = BorderStroke(width = 3.dp, brush = brushGradient),
+            ),
         )
         Text(
           text = "My Story",
           modifier = Modifier.padding(8.dp).weight(1f),
-          color = MaterialTheme.colors.onBackground
+          color = MaterialTheme.colors.onBackground,
         )
         IconButton(onClick = { closePopup.invoke() }) {
           Icon(
             imageVector = Icons.Default.Close,
             contentDescription = "Close",
-            tint = MaterialTheme.colors.onBackground
+            tint = MaterialTheme.colors.onBackground,
           )
         }
       }

--- a/demos/meditation/build.gradle.kts
+++ b/demos/meditation/build.gradle.kts
@@ -2,24 +2,20 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.meditation"
-}
+android { namespace = "com.guru.composecookbook.meditation" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":components:verticalgrid"))
+  implementation(project(":theme"))
+  implementation(project(":components:verticalgrid"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
-    
-    // Test dependencies
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
+
+  // Test dependencies
+  testImplementation("junit:junit:4.13.2")
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
 }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/BottomMenuItem.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/BottomMenuItem.kt
@@ -32,7 +32,7 @@ fun BottomMenuItem(
   activeHighlightColor: Color = ButtonBlue,
   activeTextColor: Color = Color.White,
   inactiveTextColor: Color = AquaBlue,
-  onItemClick: () -> Unit
+  onItemClick: () -> Unit,
 ) {
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,
@@ -44,13 +44,13 @@ fun BottomMenuItem(
         Modifier.clip(RoundedCornerShape(15.dp))
           .background(if (isSelected) activeHighlightColor else Color.Transparent)
           .clickable { onItemClick() }
-          .padding(15.dp)
+          .padding(15.dp),
     ) {
       Icon(
         painter = painterResource(id = item.iconId),
         contentDescription = item.title,
         tint = if (isSelected) Color.White else Gray,
-        modifier = Modifier.size(20.dp)
+        modifier = Modifier.size(20.dp),
       )
     }
     spacerHeight5()
@@ -58,7 +58,7 @@ fun BottomMenuItem(
       text = item.title,
       style = MaterialTheme.typography.h2,
       color = if (isSelected) activeTextColor else inactiveTextColor,
-      fontSize = 14.sp
+      fontSize = 14.sp,
     )
   }
 }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/CategoryItem.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/CategoryItem.kt
@@ -29,7 +29,7 @@ import com.guru.composecookbook.meditation.ui.theme.TextWhite
 fun CategoryItem(category: Categories, selectedItem: Boolean, onItemClick: () -> Unit) {
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,
-    modifier = Modifier.padding(end = 15.dp)
+    modifier = Modifier.padding(end = 15.dp),
   ) {
     Box(
       modifier =
@@ -41,7 +41,7 @@ fun CategoryItem(category: Categories, selectedItem: Boolean, onItemClick: () ->
         painter = painterResource(id = category.icon),
         contentDescription = "Category Icon",
         tint = TextWhite,
-        modifier = Modifier.padding(18.dp).size(20.dp)
+        modifier = Modifier.padding(18.dp).size(20.dp),
       )
     }
     spacerHeight5()
@@ -50,7 +50,7 @@ fun CategoryItem(category: Categories, selectedItem: Boolean, onItemClick: () ->
       style = MaterialTheme.typography.body1,
       fontSize = 12.sp,
       color = if (selectedItem) DeepBlue else Gray,
-      fontWeight = FontWeight.Bold
+      fontWeight = FontWeight.Bold,
     )
   }
 }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/DailyThoughtsItem.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/DailyThoughtsItem.kt
@@ -38,38 +38,38 @@ fun DailyThoughtsItem(dailyThought: DailyThought) {
       Image(
         painter = painterResource(id = R.drawable.ic_daily_thoughts),
         contentDescription = "Daily Thoughts",
-        Modifier.fillMaxSize()
+        Modifier.fillMaxSize(),
       )
 
       Box(modifier = Modifier.padding(horizontal = 15.dp)) {
         Row(
           horizontalArrangement = Arrangement.SpaceBetween,
           verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier.fillMaxSize()
+          modifier = Modifier.fillMaxSize(),
         ) {
           Column() {
             Text(
               text = dailyThought.title,
               style = MaterialTheme.typography.h6,
               color = dailyThought.textColor,
-              fontSize = 18.sp
+              fontSize = 18.sp,
             )
             Text(
               text = dailyThought.description,
               color = dailyThought.textColor,
               style = MaterialTheme.typography.body1,
-              fontSize = 11.sp
+              fontSize = 11.sp,
             )
           }
           Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.size(40.dp).clip(CircleShape).background(TextWhite).padding(10.dp)
+            modifier = Modifier.size(40.dp).clip(CircleShape).background(TextWhite).padding(10.dp),
           ) {
             Icon(
               painter = painterResource(id = R.drawable.ic_play),
               contentDescription = "Play",
               tint = DeepBlue,
-              modifier = Modifier.size(16.dp)
+              modifier = Modifier.size(16.dp),
             )
           }
         }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/FeatureItem.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/FeatureItem.kt
@@ -38,26 +38,26 @@ fun FeatureItem(feature: Feature, modifier: Modifier = Modifier, textColor: Colo
       Image(
         painter = painterResource(id = feature.image),
         contentDescription = feature.title,
-        modifier = Modifier.align(Alignment.TopEnd)
+        modifier = Modifier.align(Alignment.TopEnd),
       )
 
       Column(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.Start,
-        modifier = Modifier.fillMaxHeight().padding(start = 15.dp)
+        modifier = Modifier.fillMaxHeight().padding(start = 15.dp),
       ) {
         Text(
           text = feature.title,
           style = MaterialTheme.typography.h6,
           color = textColor,
           fontSize = 18.sp,
-          fontWeight = FontWeight.Bold
+          fontWeight = FontWeight.Bold,
         )
         Text(
           text = feature.description,
           color = textColor,
           style = MaterialTheme.typography.body1,
-          fontSize = 14.sp
+          fontSize = 14.sp,
         )
       }
 
@@ -67,7 +67,7 @@ fun FeatureItem(feature: Feature, modifier: Modifier = Modifier, textColor: Colo
           Modifier.fillMaxWidth()
             .fillMaxHeight()
             .padding(bottom = 15.dp, start = 15.dp, end = 15.dp),
-        verticalAlignment = Alignment.Bottom
+        verticalAlignment = Alignment.Bottom,
       ) {
         Text(text = feature.time, color = textColor, fontSize = 10.sp, fontWeight = FontWeight.Bold)
         Text(
@@ -81,7 +81,7 @@ fun FeatureItem(feature: Feature, modifier: Modifier = Modifier, textColor: Colo
               }
               .clip(RoundedCornerShape(12.dp))
               .background(ButtonBlue)
-              .padding(vertical = 6.dp, horizontal = 15.dp)
+              .padding(vertical = 6.dp, horizontal = 15.dp),
         )
       }
     }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/RecommendationItem.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/RecommendationItem.kt
@@ -25,12 +25,12 @@ import com.guru.composecookbook.meditation.ui.theme.dp10
 fun RecommendationItem(recommendation: Recommendation) {
   Column(
     horizontalAlignment = Alignment.Start,
-    modifier = Modifier.wrapContentHeight().padding(horizontal = 8.dp)
+    modifier = Modifier.wrapContentHeight().padding(horizontal = 8.dp),
   ) {
     Box(modifier = Modifier.clip(RoundedCornerShape(dp10))) {
       Image(
         painter = painterResource(id = recommendation.image),
-        contentDescription = "Recommendation Image"
+        contentDescription = "Recommendation Image",
       )
     }
 
@@ -40,13 +40,13 @@ fun RecommendationItem(recommendation: Recommendation) {
       color = DeepBlue,
       fontSize = 16.sp,
       fontWeight = FontWeight.Bold,
-      modifier = Modifier.padding(top = 5.dp)
+      modifier = Modifier.padding(top = 5.dp),
     )
     Text(
       text = recommendation.description,
       color = Color.Gray,
       style = MaterialTheme.typography.body1,
-      fontSize = 10.sp
+      fontSize = 10.sp,
     )
   }
 }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/TopicItem.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/component/TopicItem.kt
@@ -32,7 +32,7 @@ fun TopicItem(topic: Topic, itemSize: Dp) {
         painter = painterResource(id = topic.image),
         contentDescription = "Topic",
         contentScale = ContentScale.FillBounds,
-        modifier = Modifier.align(Alignment.TopCenter)
+        modifier = Modifier.align(Alignment.TopCenter),
       )
       Text(
         topic.title,
@@ -41,7 +41,7 @@ fun TopicItem(topic: Topic, itemSize: Dp) {
         lineHeight = 26.sp,
         color = topic.textColor,
         fontWeight = FontWeight.Bold,
-        modifier = Modifier.align(Alignment.BottomStart).padding(bottom = dp10, start = dp10)
+        modifier = Modifier.align(Alignment.BottomStart).padding(bottom = dp10, start = dp10),
       )
     }
   }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/model/Recommendation.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/model/Recommendation.kt
@@ -10,12 +10,12 @@ val recommendationList =
     Recommendation(
       "Happiness",
       description = "MEDITATION • 3-10 MIN",
-      R.drawable.ic_recommendation_2
+      R.drawable.ic_recommendation_2,
     ),
     Recommendation("Focus", description = "MEDITATION • 3-10 MIN", R.drawable.ic_recommendation_1),
     Recommendation(
       "Happiness",
       description = "MEDITATION • 3-10 MIN",
-      R.drawable.ic_recommendation_2
+      R.drawable.ic_recommendation_2,
     ),
   )

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/screen/HomeScreen.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/screen/HomeScreen.kt
@@ -83,7 +83,7 @@ fun MeditationHome() {
     LazyColumn(
       verticalArrangement = Arrangement.Top,
       horizontalAlignment = Alignment.Start,
-      modifier = Modifier.padding(bottom = 100.dp)
+      modifier = Modifier.padding(bottom = 100.dp),
     ) {
       item {
         appTitle()
@@ -111,14 +111,14 @@ fun appTitle() {
   Row(
     modifier = Modifier.fillMaxWidth().padding(horizontal = 15.dp, vertical = 15.dp),
     horizontalArrangement = Arrangement.Center,
-    verticalAlignment = Alignment.CenterVertically
+    verticalAlignment = Alignment.CenterVertically,
   ) {
     Text(
       text = stringResource(R.string.silent),
       style = MaterialTheme.typography.h1,
       fontSize = 16.sp,
       textAlign = TextAlign.Center,
-      color = DeepBlue
+      color = DeepBlue,
     )
     Spacer(modifier = Modifier.width(10.dp))
     Image(painter = painterResource(id = R.drawable.ic_logo), contentDescription = "App Icon")
@@ -127,7 +127,7 @@ fun appTitle() {
       text = stringResource(R.string.moon),
       style = MaterialTheme.typography.h1,
       fontSize = 16.sp,
-      color = DeepBlue
+      color = DeepBlue,
     )
   }
 }
@@ -135,19 +135,19 @@ fun appTitle() {
 @Composable
 fun greetingSection(
   modifier: Modifier = Modifier.wrapContentHeight(),
-  name: String = stringResource(R.string.your_name)
+  name: String = stringResource(R.string.your_name),
 ) {
   Column(modifier = Modifier.padding(horizontal = 15.dp)) {
     Text(
       text = stringResource(R.string.good_morning) + " $name",
       style = MaterialTheme.typography.h1,
-      fontSize = 22.sp
+      fontSize = 22.sp,
     )
     Text(
       text = stringResource(R.string.wishing_desc),
       style = MaterialTheme.typography.body1,
       color = Gray,
-      fontSize = 18.sp
+      fontSize = 18.sp,
     )
   }
 }
@@ -160,7 +160,7 @@ fun FeatureSection() {
         stringResource(R.string.basic),
         description = stringResource(R.string.course),
         R.drawable.ic_feature_1,
-        stringResource(R.string.feature_time)
+        stringResource(R.string.feature_time),
       ),
       Modifier.weight(1f)
         .padding(end = 7.5.dp)
@@ -168,14 +168,14 @@ fun FeatureSection() {
         .clip(RoundedCornerShape(dp10))
         .background(Blue)
         .wrapContentHeight(),
-      TextWhite
+      TextWhite,
     )
     FeatureItem(
       Feature(
         stringResource(R.string.relaxation),
         stringResource(R.string.music),
         R.drawable.ic_feature_2,
-        stringResource(R.string.feature_time)
+        stringResource(R.string.feature_time),
       ),
       Modifier.weight(1f)
         .padding(start = 7.5.dp)
@@ -183,7 +183,7 @@ fun FeatureSection() {
         .clip(RoundedCornerShape(dp10))
         .background(Orange)
         .wrapContentHeight(),
-      DeepBlue
+      DeepBlue,
     )
   }
 }
@@ -195,7 +195,7 @@ fun DailyThoughtsSection() {
       DailyThought(
         stringResource(R.string.daily_thoughts),
         stringResource(R.string.meditation_time),
-        TextWhite
+        TextWhite,
       )
     )
   }
@@ -209,7 +209,7 @@ fun RecommendationSection(recommendationList: List<Recommendation>) {
       text = stringResource(R.string.recommendations),
       style = MaterialTheme.typography.h2,
       textAlign = TextAlign.Start,
-      fontSize = 20.sp
+      fontSize = 20.sp,
     )
     spacerHeight10()
     LazyRow(contentPadding = PaddingValues(horizontal = 7.dp)) {
@@ -239,14 +239,14 @@ fun BottomMenu(
   activeHighlightColor: Color = Blue,
   activeTextColor: Color = Blue,
   inactiveTextColor: Color = Gray,
-  initialSelectedItemIndex: Int = 0
+  initialSelectedItemIndex: Int = 0,
 ) {
   var selectedItemIndex by remember { mutableStateOf(initialSelectedItemIndex) }
   Box(modifier = modifier.shadow(elevation = 8.dp)) {
     Row(
       horizontalArrangement = Arrangement.SpaceAround,
       verticalAlignment = Alignment.CenterVertically,
-      modifier = modifier.fillMaxWidth().background(White).padding(15.dp).height(80.dp)
+      modifier = modifier.fillMaxWidth().background(White).padding(15.dp).height(80.dp),
     ) {
       items.forEachIndexed { index, item ->
         BottomMenuItem(
@@ -254,7 +254,7 @@ fun BottomMenu(
           isSelected = index == selectedItemIndex,
           activeHighlightColor = activeHighlightColor,
           activeTextColor = activeTextColor,
-          inactiveTextColor = inactiveTextColor
+          inactiveTextColor = inactiveTextColor,
         ) {
           selectedItemIndex = index
         }
@@ -275,7 +275,7 @@ fun TopicSection(topicList: List<Topic>) {
       style = MaterialTheme.typography.h2,
       textAlign = TextAlign.Start,
       fontSize = 20.sp,
-      modifier = Modifier.padding(start = 7.5.dp)
+      modifier = Modifier.padding(start = 7.5.dp),
     )
     spacerHeight10()
     val itemSize: Dp = (LocalConfiguration.current.screenWidthDp.dp / 2) - 23.dp

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/theme/Shape.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/theme/Shape.kt
@@ -8,5 +8,5 @@ val Shapes =
   Shapes(
     small = RoundedCornerShape(4.dp),
     medium = RoundedCornerShape(4.dp),
-    large = RoundedCornerShape(0.dp)
+    large = RoundedCornerShape(0.dp),
   )

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/theme/Theme.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/theme/Theme.kt
@@ -7,11 +7,7 @@ import androidx.compose.runtime.Composable
 @Composable
 fun MeditationAppTheme(
   darkTheme: Boolean = isSystemInDarkTheme(),
-  content: @Composable() () -> Unit
+  content: @Composable() () -> Unit,
 ) {
-  MaterialTheme(
-    typography = Typography,
-    shapes = Shapes,
-    content = content,
-  )
+  MaterialTheme(typography = Typography, shapes = Shapes, content = content)
 }

--- a/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/theme/Type.kt
+++ b/demos/meditation/src/main/java/com/guru/composecookbook/meditation/ui/theme/Type.kt
@@ -27,21 +27,21 @@ val Typography =
         color = DeepBlue,
         fontFamily = sans,
         fontWeight = FontWeight.Normal,
-        fontSize = 14.sp
+        fontSize = 14.sp,
       ),
     h1 =
       TextStyle(
         color = DeepBlue,
         fontFamily = sans,
         fontWeight = FontWeight.Black,
-        fontSize = 22.sp
+        fontSize = 22.sp,
       ),
     h2 =
       TextStyle(
         color = DeepBlue,
         fontFamily = sans,
         fontWeight = FontWeight.Bold,
-        fontSize = 18.sp
+        fontSize = 18.sp,
       ),
-    defaultFontFamily = sans
+    defaultFontFamily = sans,
   )

--- a/demos/moviesapp/app/build.gradle.kts
+++ b/demos/moviesapp/app/build.gradle.kts
@@ -5,28 +5,24 @@ import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 import com.guru.composecookbook.build.dependencies.addThirdPartyUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.moviesapp"
-}
+android { namespace = "com.guru.composecookbook.moviesapp" }
 
 dependencies {
-    implementation(project(":components:tags"))
-    implementation(project(":components:carousel"))
-    implementation(project(":demos:moviesapp:data"))
-    implementation(project(":theme"))
-    implementation(project(":data"))
+  implementation(project(":components:tags"))
+  implementation(project(":components:carousel"))
+  implementation(project(":demos:moviesapp:data"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
 
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
 
-    addCoreAndroidUiDependencies()
-    addThirdPartyUiDependencies()
+  addCoreAndroidUiDependencies()
+  addThirdPartyUiDependencies()
 
-    addCoreAndroidDependencies()
+  addCoreAndroidDependencies()
 }

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/details/MovieDetailActivity.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/details/MovieDetailActivity.kt
@@ -25,6 +25,7 @@ class MovieDetailActivity : ComponentActivity() {
   companion object {
     const val MOVIE = "movie"
     const val IMAGE_ID = "imageId"
+
     fun newIntent(context: Context, movie: Movie) =
       Intent(context, MovieDetailActivity::class.java).apply { putExtra(MOVIE, movie) }
 

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/details/components/MovieDetailContent.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/details/components/MovieDetailContent.kt
@@ -83,14 +83,14 @@ fun MovieDetailContent(movie: Movie, imageId: Int) {
         Row(
           horizontalArrangement = Arrangement.SpaceBetween,
           verticalAlignment = Alignment.CenterVertically,
-          modifier = Modifier.fillMaxWidth()
+          modifier = Modifier.fillMaxWidth(),
         ) {
           Text(text = movie.title, modifier = Modifier.padding(8.dp), style = typography.h6)
           IconButton(onClick = {}) {
             Icon(
               imageVector = Icons.Default.LibraryAdd,
               contentDescription = null,
-              tint = MaterialTheme.colors.primary
+              tint = MaterialTheme.colors.primary,
             )
           }
         }
@@ -98,12 +98,12 @@ fun MovieDetailContent(movie: Movie, imageId: Int) {
         Text(
           text = "Release: ${movie.release_date}",
           modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-          style = typography.h6.copy(fontSize = 12.sp)
+          style = typography.h6.copy(fontSize = 12.sp),
         )
         Text(
           text = "PG13  •  ${movie.vote_average}/10",
           modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-          style = typography.h6.copy(fontSize = 12.sp, fontWeight = FontWeight.Medium)
+          style = typography.h6.copy(fontSize = 12.sp, fontWeight = FontWeight.Medium),
         )
         Text(text = movie.overview, modifier = Modifier.padding(8.dp), style = typography.subtitle2)
         Spacer(modifier = Modifier.height(20.dp))

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/details/components/SimilarMoviesSection.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/details/components/SimilarMoviesSection.kt
@@ -36,9 +36,9 @@ fun SimilarMoviesSection(currentMovie: Movie?, viewModel: MovieDetailViewModel) 
             contentDescription = null,
             modifier =
               Modifier.width(200.dp).height(300.dp).padding(12.dp).clip(RoundedCornerShape(12.dp)),
-            contentScale = ContentScale.Crop
+            contentScale = ContentScale.Crop,
           )
-        }
+        },
       )
     }
   }

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/MoviesHomeActivity.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/MoviesHomeActivity.kt
@@ -40,6 +40,7 @@ sealed class MoviesHomeInteractionEvents {
     MoviesHomeInteractionEvents()
 
   data class AddToMyWatchlist(val movie: Movie) : MoviesHomeInteractionEvents()
+
   data class RemoveFromMyWatchlist(val movie: Movie) : MoviesHomeInteractionEvents()
 }
 
@@ -54,10 +55,7 @@ class MoviesHomeActivity : ComponentActivity() {
         val viewModel: MoviesHomeViewModel =
           viewModel(factory = MoviesHomeViewModelFactory(LocalContext.current))
         Scaffold(bottomBar = { MoviesBottomBar(navType) }) {
-          Crossfade(
-            targetState = navType,
-            modifier = Modifier.padding(it),
-          ) { navTypeState ->
+          Crossfade(targetState = navType, modifier = Modifier.padding(it)) { navTypeState ->
             when (navTypeState.value) {
               MovieNavType.SHOWING ->
                 MovieHomeScreen(
@@ -86,7 +84,7 @@ class MoviesHomeActivity : ComponentActivity() {
 
   private fun handleInteractionEvents(
     interactionEvents: MoviesHomeInteractionEvents,
-    viewModel: MoviesHomeViewModel
+    viewModel: MoviesHomeViewModel,
   ) {
     when (interactionEvents) {
       is MoviesHomeInteractionEvents.OpenMovieDetail -> {
@@ -106,6 +104,7 @@ class MoviesHomeActivity : ComponentActivity() {
 
   companion object {
     private const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, isDarkTheme: Boolean) =
       Intent(context, MoviesHomeActivity::class.java).apply { putExtra(DARK_THEME, isDarkTheme) }
   }
@@ -126,13 +125,13 @@ fun MoviesBottomBar(navType: MutableState<MovieNavType>) {
       icon = { Icon(imageVector = Icons.Outlined.Subscriptions, contentDescription = null) },
       selected = navType.value == MovieNavType.TRENDING,
       onClick = { navType.value = MovieNavType.TRENDING },
-      label = { Text(text = "Trending") }
+      label = { Text(text = "Trending") },
     )
     BottomNavigationItem(
       icon = { Icon(imageVector = Icons.Outlined.LibraryAdd, contentDescription = null) },
       selected = navType.value == MovieNavType.WATCHLIST,
       onClick = { navType.value = MovieNavType.WATCHLIST },
-      label = { Text(text = "Watchlist") }
+      label = { Text(text = "Watchlist") },
     )
   }
 }
@@ -140,5 +139,5 @@ fun MoviesBottomBar(navType: MutableState<MovieNavType>) {
 enum class MovieNavType {
   SHOWING,
   TRENDING,
-  WATCHLIST
+  WATCHLIST,
 }

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/components/MoviePagerItem.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/components/MoviePagerItem.kt
@@ -50,14 +50,14 @@ fun MoviePagerItem(
   isSelected: Boolean,
   offset: Float,
   addToWatchList: () -> Unit,
-  openMovieDetail: () -> Unit
+  openMovieDetail: () -> Unit,
 ) {
   val animateHeight =
     getOffsetBasedValue(
         selectedValue = 645,
         nonSelectedValue = 360,
         isSelected = isSelected,
-        offset = offset
+        offset = offset,
       )
       .dp
   val animateWidth =
@@ -65,7 +65,7 @@ fun MoviePagerItem(
         selectedValue = 340,
         nonSelectedValue = 320,
         isSelected = isSelected,
-        offset = offset
+        offset = offset,
       )
       .dp
   val animateElevation =
@@ -73,7 +73,7 @@ fun MoviePagerItem(
         selectedValue = 12,
         nonSelectedValue = 2,
         isSelected = isSelected,
-        offset = offset
+        offset = offset,
       )
       .dp
 
@@ -97,12 +97,12 @@ fun MoviePagerItem(
         painter = rememberImagePainter(data = posterFullPath),
         contentScale = ContentScale.Crop,
         contentDescription = null,
-        modifier = Modifier.fillMaxWidth().height(360.dp)
+        modifier = Modifier.fillMaxWidth().height(360.dp),
       )
       Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
       ) {
         val clicked = remember { mutableStateOf(false) }
         Text(text = movie.title, modifier = Modifier.padding(8.dp), style = typography.h6)
@@ -119,7 +119,7 @@ fun MoviePagerItem(
             modifier =
               Modifier.graphicsLayer(
                 rotationY = animateFloatAsState(if (clicked.value) 720f else 0f, tween(400)).value
-              )
+              ),
           )
         }
       }
@@ -127,19 +127,19 @@ fun MoviePagerItem(
       Text(
         text = "Release: ${movie.release_date}",
         modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-        style = typography.h6.copy(fontSize = 12.sp)
+        style = typography.h6.copy(fontSize = 12.sp),
       )
       Text(
         text = "PG13  •  ${movie.vote_average}/10",
         modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-        style = typography.h6.copy(fontSize = 12.sp, fontWeight = FontWeight.Medium)
+        style = typography.h6.copy(fontSize = 12.sp, fontWeight = FontWeight.Medium),
       )
       Text(
         text = movie.overview,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         modifier = Modifier.align(Alignment.CenterHorizontally).padding(8.dp).weight(1f),
-        style = typography.subtitle2
+        style = typography.subtitle2,
       )
       Button(onClick = {}, modifier = Modifier.fillMaxWidth()) {
         Text(text = "Get Tickets", modifier = Modifier.padding(8.dp))

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/components/MoviesHomeScreen.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/components/MoviesHomeScreen.kt
@@ -50,7 +50,7 @@ fun MovieHomeScreenContent(moviesHomeInteractionEvents: (MoviesHomeInteractionEv
       Text(
         text = "Now Showing",
         style = typography.h5.copy(fontWeight = FontWeight.ExtraBold),
-        modifier = Modifier.padding(16.dp)
+        modifier = Modifier.padding(16.dp),
       )
     }
     item { MoviesPager(imageId, moviesHomeInteractionEvents) }

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/components/MoviesPager.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/home/components/MoviesPager.kt
@@ -25,7 +25,7 @@ import kotlin.math.abs
 @Composable
 fun MoviesPager(
   imageId: MutableState<Int>,
-  moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -> Unit
+  moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -> Unit,
 ) {
   val moviesViewModel: MoviesHomeViewModel =
     viewModel(factory = MoviesHomeViewModelFactory(LocalContext.current))
@@ -53,7 +53,7 @@ fun MoviesPager(
         genres,
         isSelected,
         filteredOffset,
-        { moviesHomeInteractionEvents(MoviesHomeInteractionEvents.AddToMyWatchlist(movie)) }
+        { moviesHomeInteractionEvents(MoviesHomeInteractionEvents.AddToMyWatchlist(movie)) },
       ) {
         moviesHomeInteractionEvents(
           MoviesHomeInteractionEvents.OpenMovieDetail(movie, imageId.value)

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/trending/components/MovieTrendingScreen.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/trending/components/MovieTrendingScreen.kt
@@ -57,7 +57,7 @@ fun DynamicSection(
   type: String,
   viewModel: TrendingViewModel,
   showLoading: MutableState<Boolean>,
-  moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -> Unit
+  moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -> Unit,
 ) {
   val movies by
     when (type) {

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/trending/components/MoviesLaneItem.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/trending/components/MoviesLaneItem.kt
@@ -24,7 +24,7 @@ fun MoviesLaneItem(movies: List<Movie>, title: String = "", onMovieSelected: (Mo
     Text(
       text = title,
       style = typography.h6,
-      modifier = Modifier.padding(start = 16.dp, end = 8.dp, bottom = 8.dp, top = 24.dp)
+      modifier = Modifier.padding(start = 16.dp, end = 8.dp, bottom = 8.dp, top = 24.dp),
     )
   }
   LazyRow {
@@ -33,9 +33,7 @@ fun MoviesLaneItem(movies: List<Movie>, title: String = "", onMovieSelected: (Mo
       itemContent = { movie: Movie ->
         Image(
           painter =
-            rememberImagePainter(
-              data = "https://image.tmdb.org/t/p/w500/${movie.poster_path}",
-            ),
+            rememberImagePainter(data = "https://image.tmdb.org/t/p/w500/${movie.poster_path}"),
           contentDescription = null,
           modifier =
             Modifier.width(190.dp)
@@ -43,9 +41,9 @@ fun MoviesLaneItem(movies: List<Movie>, title: String = "", onMovieSelected: (Mo
               .padding(12.dp)
               .clip(RoundedCornerShape(12.dp))
               .clickable(onClick = { onMovieSelected(movie) }),
-          contentScale = ContentScale.Crop
+          contentScale = ContentScale.Crop,
         )
-      }
+      },
     )
   }
 }

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/EmptyWatchlistSection.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/EmptyWatchlistSection.kt
@@ -19,7 +19,7 @@ fun EmptyWatchlistSection() {
       text = "Watchlist is empty",
       style = typography.h6,
       modifier = Modifier.fillMaxWidth(),
-      textAlign = TextAlign.Center
+      textAlign = TextAlign.Center,
     )
     Text(
       text = "Please add some movies to your watchlist",

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/MovieWatchlistItem.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/MovieWatchlistItem.kt
@@ -28,7 +28,7 @@ import com.guru.composecookbook.theme.typography
 fun MovieWatchlistItem(
   movie: Movie,
   onMovieSelected: () -> Unit,
-  onRemoveFromWatchlist: () -> Unit
+  onRemoveFromWatchlist: () -> Unit,
 ) {
   Box(modifier = Modifier.clickable(onClick = onMovieSelected)) {
     Image(
@@ -36,7 +36,7 @@ fun MovieWatchlistItem(
         rememberImagePainter(data = "https://image.tmdb.org/t/p/original/${movie.backdrop_path}"),
       contentDescription = null,
       modifier = Modifier.fillMaxWidth().height(280.dp),
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Spacer( // overlay
       modifier = Modifier.fillMaxWidth().height(280.dp).background(Color.Black.copy(alpha = 0.1f))
@@ -44,11 +44,11 @@ fun MovieWatchlistItem(
     Text(
       text = movie.title,
       style = typography.h6.copy(fontWeight = FontWeight.ExtraBold),
-      modifier = Modifier.align(Alignment.BottomStart).padding(8.dp)
+      modifier = Modifier.align(Alignment.BottomStart).padding(8.dp),
     )
     IconButton(
       onClick = { onRemoveFromWatchlist.invoke() },
-      modifier = Modifier.align(Alignment.BottomEnd)
+      modifier = Modifier.align(Alignment.BottomEnd),
     ) {
       Icon(imageVector = Icons.Default.RemoveCircleOutline, contentDescription = null)
     }

--- a/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/WatchlistScreen.kt
+++ b/demos/moviesapp/app/src/main/java/com/guru/composecookbook/moviesapp/ui/watch/components/WatchlistScreen.kt
@@ -39,9 +39,9 @@ fun WatchlistScreen(moviesHomeInteractionEvents: (MoviesHomeInteractionEvents) -
             { moviesHomeInteractionEvents(MoviesHomeInteractionEvents.OpenMovieDetail(movie)) },
             {
               moviesHomeInteractionEvents(MoviesHomeInteractionEvents.RemoveFromMyWatchlist(movie))
-            }
+            },
           )
-        }
+        },
       )
     }
   }

--- a/demos/moviesapp/data/build.gradle.kts
+++ b/demos/moviesapp/data/build.gradle.kts
@@ -3,18 +3,14 @@ import com.guru.composecookbook.build.dependencies.addDataDependencies
 import com.guru.composecookbook.build.dependencies.addNetworkingDependencies
 
 plugins {
-    /**
-     * See [common-kotlin-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-kotlin-module-configs-script-plugin")
+  /** See [common-kotlin-module-configs-script-plugin.gradle.kts] file */
+  id("common-kotlin-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.moviesapp.data"
-}
+android { namespace = "com.guru.composecookbook.moviesapp.data" }
 
 dependencies {
-    addCoreAndroidDependencies()
-    addNetworkingDependencies()
-    addDataDependencies()
+  addCoreAndroidDependencies()
+  addNetworkingDependencies()
+  addDataDependencies()
 }

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/DemoMovieDataProvider.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/DemoMovieDataProvider.kt
@@ -24,7 +24,7 @@ object DemoMovieDataProvider {
       runtime = 130,
       homepage = "https://dc.com",
       status = "Running",
-      addedTime = 123434343
+      addedTime = 123434343,
     )
 
   val movies =
@@ -37,6 +37,6 @@ object DemoMovieDataProvider {
       movie.copy(id = 6, title = "Mulan"),
       movie.copy(id = 7, title = "Mulan"),
       movie.copy(id = 8, title = "Mulan"),
-      movie.copy(id = 9, title = "Mulan")
+      movie.copy(id = 9, title = "Mulan"),
     )
 }

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/MovieDIGraph.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/MovieDIGraph.kt
@@ -17,7 +17,7 @@ object MovieDIGraph {
     return MovieRepositoryImpl(
       movieApi = movieApi,
       moviesDao = db.moviesDao(),
-      genreDao = db.genreDao()
+      genreDao = db.genreDao(),
     )
   }
 

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/api/models/MovieListResponse.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/api/models/MovieListResponse.kt
@@ -5,5 +5,5 @@ import com.guru.composecookbook.moviesapp.data.db.models.Movie
 
 data class MovieListResponse(
   @SerializedName("pages") val pages: Int,
-  @SerializedName("results") val movies: List<Movie>
+  @SerializedName("results") val movies: List<Movie>,
 )

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/db/MovieDatabase.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/db/MovieDatabase.kt
@@ -14,6 +14,7 @@ import com.guru.composecookbook.moviesapp.data.db.models.Movie
 @TypeConverters(ListTypeConverter::class)
 abstract class MoviesDatabase : RoomDatabase() {
   abstract fun moviesDao(): MoviesDao
+
   abstract fun genreDao(): GenreDao
 
   companion object {
@@ -30,7 +31,7 @@ abstract class MoviesDatabase : RoomDatabase() {
       Room.databaseBuilder(
           context.applicationContext,
           MoviesDatabase::class.java,
-          "movie_database.db"
+          "movie_database.db",
         )
         .build()
   }

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/db/models/Movie.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/db/models/Movie.kt
@@ -23,5 +23,5 @@ data class Movie(
   val homepage: String?,
   val status: String?,
   var addedTime: Long?,
-  var dominantRgb: Int = 0
+  var dominantRgb: Int = 0,
 ) : Serializable

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/repositories/MovieRepository.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/repositories/MovieRepository.kt
@@ -7,10 +7,16 @@ import kotlinx.coroutines.flow.Flow
 
 interface MovieRepository {
   suspend fun getNowShowing(): Flow<List<Movie>>
+
   suspend fun getSimilarMovies(movieId: String): Flow<List<Movie>>
+
   suspend fun getMyWatchlist(): LiveData<List<Movie>>
+
   suspend fun addToMyWatchlist(movie: Movie)
+
   suspend fun removeFromMyWatchlist(movie: Movie)
+
   suspend fun fetchAndSaveGenresToDatabase(): Flow<List<Genre>>
+
   suspend fun getGenres(): LiveData<List<Genre>>
 }

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/repositories/MovieRepositoryImpl.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/repositories/MovieRepositoryImpl.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.flowOn
 class MovieRepositoryImpl(
   private val movieApi: MovieApi,
   private val moviesDao: MoviesDao,
-  private val genreDao: GenreDao
+  private val genreDao: GenreDao,
 ) : MovieRepository {
 
   override suspend fun getNowShowing(): Flow<List<Movie>> =

--- a/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/repositories/MoviesLanesRepository.kt
+++ b/demos/moviesapp/data/src/main/java/com/guru/composecookbook/moviesapp/data/repositories/MoviesLanesRepository.kt
@@ -5,8 +5,12 @@ import kotlinx.coroutines.flow.Flow
 
 interface MoviesLanesRepository {
   suspend fun getTrendingMovies(): Flow<List<Movie>>
+
   suspend fun getPopularMovies(): Flow<List<Movie>>
+
   suspend fun getTopRatedMovies(): Flow<List<Movie>>
+
   suspend fun getTopRatedTVShwos(): Flow<List<Movie>>
+
   suspend fun getTrendingTVShows(): Flow<List<Movie>>
 }

--- a/demos/paint/build.gradle.kts
+++ b/demos/paint/build.gradle.kts
@@ -2,20 +2,16 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.paint"
-}
+android { namespace = "com.guru.composecookbook.paint" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":components:colorpicker"))
+  implementation(project(":theme"))
+  implementation(project(":components:colorpicker"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/paint/src/main/java/com/guru/composecookbook/paint/DrawingCanvas.kt
+++ b/demos/paint/src/main/java/com/guru/composecookbook/paint/DrawingCanvas.kt
@@ -21,14 +21,14 @@ import androidx.compose.ui.unit.dp
 @OptIn(
   ExperimentalComposeUiApi::class,
   ExperimentalAnimationApi::class,
-  ExperimentalFoundationApi::class
+  ExperimentalFoundationApi::class,
 )
 @Composable
 fun DrawingCanvas(
   drawColor: MutableState<Color>,
   drawBrush: MutableState<Float>,
   usedColors: MutableState<MutableSet<Color>>,
-  paths: List<PathState>
+  paths: List<PathState>,
 ) {
   val currentPath = paths.last().path
   val movePath = remember { mutableStateOf<Offset?>(null) }

--- a/demos/paint/src/main/java/com/guru/composecookbook/paint/DrawingTools.kt
+++ b/demos/paint/src/main/java/com/guru/composecookbook/paint/DrawingTools.kt
@@ -39,7 +39,7 @@ import com.guru.composecookbook.theme.modifiers.horizontalGradientBackground
 fun DrawingTools(
   drawColor: MutableState<Color>,
   drawBrush: MutableState<Float>,
-  usedColors: MutableSet<Color>
+  usedColors: MutableSet<Color>,
 ) {
   var showBrushes by remember { mutableStateOf(false) }
   val strokes = remember { (1..50 step 5).toList() }
@@ -58,7 +58,7 @@ fun DrawingTools(
           imageVector = Icons.Default.Bookmark,
           contentDescription = null,
           tint = it,
-          modifier = Modifier.padding(8.dp).clickable { drawColor.value = it }
+          modifier = Modifier.padding(8.dp).clickable { drawColor.value = it },
         )
       }
     }
@@ -82,10 +82,10 @@ fun DrawingTools(
                   border =
                     BorderStroke(
                       width = with(LocalDensity.current) { it.toDp() },
-                      color = Color.Gray
+                      color = Color.Gray,
                     ),
-                  shape = CircleShape
-                )
+                  shape = CircleShape,
+                ),
           ) {}
         }
       }

--- a/demos/paint/src/main/java/com/guru/composecookbook/paint/PaintActivity.kt
+++ b/demos/paint/src/main/java/com/guru/composecookbook/paint/PaintActivity.kt
@@ -18,7 +18,7 @@ class PaintActivity : ComponentActivity() {
   @OptIn(
     ExperimentalComposeUiApi::class,
     androidx.compose.foundation.ExperimentalFoundationApi::class,
-    androidx.compose.animation.ExperimentalAnimationApi::class
+    androidx.compose.animation.ExperimentalAnimationApi::class,
   )
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -34,7 +34,7 @@ class PaintActivity : ComponentActivity() {
 @OptIn(
   ExperimentalComposeUiApi::class,
   ExperimentalFoundationApi::class,
-  ExperimentalAnimationApi::class
+  ExperimentalAnimationApi::class,
 )
 @Preview(showBackground = true)
 @Composable

--- a/demos/paint/src/main/java/com/guru/composecookbook/paint/PaintApp.kt
+++ b/demos/paint/src/main/java/com/guru/composecookbook/paint/PaintApp.kt
@@ -22,10 +22,7 @@ import androidx.compose.ui.graphics.Path
 fun PaintApp() {
   val paths = remember { mutableStateOf(mutableListOf<PathState>()) }
   Scaffold(topBar = { PaintAppBar { paths.value = mutableListOf() } }) { paddingValues ->
-    PaintBody(
-      paths = paths,
-      modifier = Modifier.padding(paddingValues),
-    )
+    PaintBody(paths = paths, modifier = Modifier.padding(paddingValues))
   }
 }
 
@@ -36,17 +33,14 @@ fun PaintAppBar(onDelete: () -> Unit) {
     actions = {
       IconButton(
         onClick = onDelete,
-        content = { Icon(imageVector = Icons.Default.Delete, contentDescription = null) }
+        content = { Icon(imageVector = Icons.Default.Delete, contentDescription = null) },
       )
-    }
+    },
   )
 }
 
 @Composable
-fun PaintBody(
-  paths: MutableState<MutableList<PathState>>,
-  modifier: Modifier = Modifier,
-) {
+fun PaintBody(paths: MutableState<MutableList<PathState>>, modifier: Modifier = Modifier) {
   Box(modifier = modifier.fillMaxSize()) {
     val drawColor = remember { mutableStateOf(Color.Black) }
     val drawBrush = remember { mutableStateOf(5f) }

--- a/demos/spotify/build.gradle.kts
+++ b/demos/spotify/build.gradle.kts
@@ -2,21 +2,17 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.spotify"
-}
+android { namespace = "com.guru.composecookbook.spotify" }
 
 dependencies {
-    implementation(project(":components:verticalgrid"))
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":components:verticalgrid"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/SpotifyDetailActivity.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/SpotifyDetailActivity.kt
@@ -25,6 +25,7 @@ class SpotifyDetailActivity : ComponentActivity() {
 
   companion object {
     const val ALBUM = "album"
+
     fun newIntent(context: Context, album: Album) =
       Intent(context, SpotifyDetailActivity::class.java).apply { putExtra(ALBUM, album) }
   }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/BoxTopSection.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/BoxTopSection.kt
@@ -40,13 +40,13 @@ fun BoxTopSection(album: Album, scrollState: ScrollState) {
     Image(
       painter = painterResource(id = album.imageId),
       contentDescription = null,
-      modifier = Modifier.size(animateImageSize).padding(8.dp)
+      modifier = Modifier.size(animateImageSize).padding(8.dp),
     )
     Text(
       text = album.song,
       style = typography.h5.copy(fontWeight = FontWeight.ExtraBold),
       modifier = Modifier.padding(8.dp),
-      color = MaterialTheme.colors.onSurface
+      color = MaterialTheme.colors.onSurface,
     )
     Text(
       text = "FOLLOWING",
@@ -56,9 +56,9 @@ fun BoxTopSection(album: Album, scrollState: ScrollState) {
         Modifier.padding(4.dp)
           .border(
             border = BorderStroke(2.dp, MaterialTheme.colors.primaryVariant),
-            shape = RoundedCornerShape(12.dp)
+            shape = RoundedCornerShape(12.dp),
           )
-          .padding(vertical = 4.dp, horizontal = 24.dp)
+          .padding(vertical = 4.dp, horizontal = 24.dp),
     )
     Text(text = album.descriptions, style = typography.subtitle2, modifier = Modifier.padding(4.dp))
   }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/SongListScrollingSection.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/SongListScrollingSection.kt
@@ -36,19 +36,19 @@ fun SongListScrollingSection() {
 fun DownloadedRow() {
   Row(
     modifier = Modifier.fillMaxWidth().padding(16.dp),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Text(
       text = "Download",
       style = typography.h6.copy(fontSize = 14.sp),
-      color = MaterialTheme.colors.onSurface
+      color = MaterialTheme.colors.onSurface,
     )
     var switched by remember { mutableStateOf(true) }
     Switch(
       checked = switched,
       colors = SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colors.primary),
       modifier = Modifier.padding(8.dp),
-      onCheckedChange = { switched = it }
+      onCheckedChange = { switched = it },
     )
   }
 }
@@ -65,7 +65,7 @@ fun ShuffleButton() {
       text = "SHUFFLE PLAY",
       style = typography.h6.copy(fontSize = 14.sp),
       color = MaterialTheme.colors.onSurface,
-      modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp)
+      modifier = Modifier.padding(vertical = 8.dp, horizontal = 16.dp),
     )
   }
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/SpotifyDetailScreen.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/SpotifyDetailScreen.kt
@@ -73,23 +73,23 @@ fun AnimatedToolBar(album: Album, scrollState: ScrollState, surfaceGradient: Lis
             listOf(Color.Transparent, Color.Transparent)
           else surfaceGradient
         )
-        .padding(horizontal = 8.dp, vertical = 4.dp)
+        .padding(horizontal = 8.dp, vertical = 4.dp),
   ) {
     Icon(
       imageVector = Icons.Default.ArrowBack,
       tint = MaterialTheme.colors.onSurface,
-      contentDescription = stringResource(id = R.string.cd_back)
+      contentDescription = stringResource(id = R.string.cd_back),
     )
     Text(
       text = album.song,
       color = MaterialTheme.colors.onSurface,
       modifier =
-        Modifier.padding(16.dp).alpha(((scrollState.value + 0.001f) / 1000).coerceIn(0f, 1f))
+        Modifier.padding(16.dp).alpha(((scrollState.value + 0.001f) / 1000).coerceIn(0f, 1f)),
     )
     Icon(
       imageVector = Icons.Default.MoreVert,
       tint = MaterialTheme.colors.onSurface,
-      contentDescription = null
+      contentDescription = null,
     )
   }
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/SpotifySongListItem.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/details/components/SpotifySongListItem.kt
@@ -27,27 +27,24 @@ import com.guru.composecookbook.theme.typography
 
 @Composable
 fun SpotifySongListItem(album: Album) {
-  Row(
-    modifier = Modifier.padding(8.dp),
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
+  Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
     Image(
       painter = painterResource(id = album.imageId),
       contentDescription = null,
       contentScale = ContentScale.Crop,
-      modifier = Modifier.size(55.dp).padding(4.dp)
+      modifier = Modifier.size(55.dp).padding(4.dp),
     )
     Column(modifier = Modifier.padding(horizontal = 4.dp).weight(1f)) {
       Text(
         text = album.song,
         style = typography.h6.copy(fontSize = 16.sp),
-        color = MaterialTheme.colors.onSurface
+        color = MaterialTheme.colors.onSurface,
       )
       Text(
         text = "${album.artist}, ${album.descriptions}",
         style = typography.subtitle2,
         maxLines = 1,
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
       )
     }
     if (album.id % 3 == 0) {
@@ -55,14 +52,14 @@ fun SpotifySongListItem(album: Album) {
         imageVector = Icons.Default.Favorite,
         contentDescription = null,
         tint = MaterialTheme.colors.primaryVariant,
-        modifier = Modifier.padding(4.dp).size(20.dp)
+        modifier = Modifier.padding(4.dp).size(20.dp),
       )
     }
     Icon(
       imageVector = Icons.Default.MoreVert,
       contentDescription = null,
       tint = Color.LightGray,
-      modifier = Modifier.padding(4.dp)
+      modifier = Modifier.padding(4.dp),
     )
   }
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/SpotifyActivity.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/SpotifyActivity.kt
@@ -36,7 +36,7 @@ import com.guru.composecookbook.theme.graySurface
 enum class SpotifyNavType {
   HOME,
   SEARCH,
-  LIBRARY
+  LIBRARY,
 }
 
 class SpotifyActivity : ComponentActivity() {
@@ -48,6 +48,7 @@ class SpotifyActivity : ComponentActivity() {
 
   companion object {
     const val DARK_THEME = "darkTheme"
+
     fun newIntent(context: Context, isDarkTheme: Boolean) =
       Intent(context, SpotifyActivity::class.java).apply { putExtra(DARK_THEME, isDarkTheme) }
   }
@@ -59,11 +60,8 @@ fun SpotifyAppContent() {
   Scaffold(
     bottomBar = { SpotifyBottomNavigation(spotifyNavItemState) },
     content = { paddingValues ->
-      SpotifyBodyContent(
-        spotifyNavItemState.value,
-        modifier = Modifier.padding(paddingValues),
-      )
-    }
+      SpotifyBodyContent(spotifyNavItemState.value, modifier = Modifier.padding(paddingValues))
+    },
   )
 }
 
@@ -82,26 +80,20 @@ fun SpotifyBottomNavigation(spotifyNavItemState: MutableState<SpotifyNavType>) {
       icon = { Icon(imageVector = Icons.Outlined.Search, contentDescription = null) },
       selected = spotifyNavItemState.value == SpotifyNavType.SEARCH,
       onClick = { spotifyNavItemState.value = SpotifyNavType.SEARCH },
-      label = { Text(text = stringResource(id = R.string.spotify_nav_search)) }
+      label = { Text(text = stringResource(id = R.string.spotify_nav_search)) },
     )
     BottomNavigationItem(
       icon = { Icon(imageVector = Icons.Outlined.LibraryMusic, contentDescription = null) },
       selected = spotifyNavItemState.value == SpotifyNavType.LIBRARY,
       onClick = { spotifyNavItemState.value = SpotifyNavType.LIBRARY },
-      label = { Text(text = stringResource(id = R.string.spotify_nav_library)) }
+      label = { Text(text = stringResource(id = R.string.spotify_nav_library)) },
     )
   }
 }
 
 @Composable
-fun SpotifyBodyContent(
-  spotifyNavType: SpotifyNavType,
-  modifier: Modifier = Modifier,
-) {
-  Crossfade(
-    targetState = spotifyNavType,
-    modifier = modifier,
-  ) { navType ->
+fun SpotifyBodyContent(spotifyNavType: SpotifyNavType, modifier: Modifier = Modifier) {
+  Crossfade(targetState = spotifyNavType, modifier = modifier) { navType ->
     when (navType) {
       SpotifyNavType.HOME -> SpotifyHome()
       SpotifyNavType.SEARCH -> SpotifySearchScreen()

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/PlayerBottomBar.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/PlayerBottomBar.kt
@@ -37,7 +37,7 @@ fun PlayerBottomBar(modifier: Modifier) {
       painter = painterResource(id = R.drawable.adele21),
       modifier = Modifier.size(65.dp),
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Text(
       text = "Someone Like you by Adele",
@@ -47,12 +47,12 @@ fun PlayerBottomBar(modifier: Modifier) {
     Icon(
       imageVector = Icons.Default.FavoriteBorder,
       modifier = Modifier.padding(8.dp),
-      contentDescription = null
+      contentDescription = null,
     )
     Icon(
       imageVector = Icons.Default.PlayArrow,
       modifier = Modifier.padding(8.dp),
-      contentDescription = null
+      contentDescription = null,
     )
   }
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/SpotifyHome.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/SpotifyHome.kt
@@ -48,7 +48,7 @@ fun SpotifyHome() {
       modifier =
         Modifier.align(Alignment.TopEnd)
           .padding(start = 12.dp, end = 12.dp, top = 36.dp, bottom = 12.dp)
-          .alpha(animateFloatAsState(1f - scrollState.value / 200f).value)
+          .alpha(animateFloatAsState(1f - scrollState.value / 200f).value),
     )
     PlayerBottomBar(Modifier.align(Alignment.BottomCenter))
   }
@@ -76,7 +76,7 @@ fun SpotifyTitle(text: String, modifier: Modifier = Modifier) {
     text = text,
     style = typography.h5.copy(fontWeight = FontWeight.ExtraBold),
     modifier =
-      modifier.padding(start = 8.dp, end = 4.dp, bottom = 8.dp, top = 24.dp).semantics { heading() }
+      modifier.padding(start = 8.dp, end = 4.dp, bottom = 8.dp, top = 24.dp).semantics { heading() },
   )
 }
 

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/SpotifyHomeGridItem.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/SpotifyHomeGridItem.kt
@@ -31,19 +31,19 @@ fun SpotifyHomeGridItem(album: Album) {
   Card(
     elevation = 4.dp,
     backgroundColor = cardColor,
-    modifier = Modifier.clip(RoundedCornerShape(8.dp)).padding(8.dp).clickable(onClick = {})
+    modifier = Modifier.clip(RoundedCornerShape(8.dp)).padding(8.dp).clickable(onClick = {}),
   ) {
     Row(verticalAlignment = Alignment.CenterVertically) {
       Image(
         painter = painterResource(id = album.imageId),
         contentDescription = null,
         modifier = Modifier.size(55.dp),
-        contentScale = ContentScale.Crop
+        contentScale = ContentScale.Crop,
       )
       Text(
         text = album.song,
         style = typography.h6.copy(fontSize = 14.sp),
-        modifier = Modifier.padding(horizontal = 8.dp)
+        modifier = Modifier.padding(horizontal = 8.dp),
       )
     }
   }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/SpotifyLaneItem.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/home/components/SpotifyLaneItem.kt
@@ -39,14 +39,14 @@ fun SpotifyLaneItem(album: Album) {
       painter = painterResource(id = album.imageId),
       modifier = Modifier.width(180.dp).height(160.dp),
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Text(
       text = "${album.song}: ${album.descriptions}",
       style = typography.body2,
       maxLines = 2,
       overflow = TextOverflow.Ellipsis,
-      modifier = Modifier.padding(vertical = 8.dp)
+      modifier = Modifier.padding(vertical = 8.dp),
     )
   }
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/playlist/components/SpotifyPlaylist.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/playlist/components/SpotifyPlaylist.kt
@@ -62,19 +62,19 @@ fun PlaylistItemWithRandomHeight(album: Album, context: Context) {
             // Disclaimer: We should pass event top level and there should startActivity
             context.startActivity(SpotifyDetailActivity.newIntent(context, album))
           }
-        )
+        ),
   ) {
     Column {
       Image(
         painter = painterResource(album.imageId),
         contentScale = ContentScale.Crop,
         contentDescription = null,
-        modifier = Modifier.height(randomHeight)
+        modifier = Modifier.height(randomHeight),
       )
       Text(
         text = album.artist,
         modifier = Modifier.padding(8.dp),
-        style = MaterialTheme.typography.h6.copy(fontSize = 14.sp)
+        style = MaterialTheme.typography.h6.copy(fontSize = 14.sp),
       )
     }
   }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/search/components/SpotifySearchBar.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/search/components/SpotifySearchBar.kt
@@ -25,7 +25,7 @@ fun SpotifySearchBar() {
   Card(
     elevation = 4.dp,
     modifier = Modifier.fillMaxWidth().padding(12.dp).clip(RoundedCornerShape(4.dp)),
-    backgroundColor = MaterialTheme.colors.onSurface
+    backgroundColor = MaterialTheme.colors.onSurface,
   ) {
     Row(
       horizontalArrangement = Arrangement.Center,

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/search/components/SpotifySearchGrid.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/search/components/SpotifySearchGrid.kt
@@ -60,12 +60,12 @@ fun SpotifySearchGridItem(album: Album) {
         .height(100.dp)
         .clip(RoundedCornerShape(8.dp))
         .horizontalGradientBackground(dominantGradient),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Text(
       text = album.song,
       style = typography.h6.copy(fontSize = 14.sp),
-      modifier = Modifier.padding(8.dp)
+      modifier = Modifier.padding(8.dp),
     )
     Image(
       painter = painterResource(id = album.imageId),
@@ -74,7 +74,7 @@ fun SpotifySearchGridItem(album: Album) {
       modifier =
         Modifier.size(70.dp)
           .align(Alignment.Bottom)
-          .graphicsLayer(translationX = 40f, rotationZ = 32f, shadowElevation = 16f)
+          .graphicsLayer(translationX = 40f, rotationZ = 32f, shadowElevation = 16f),
     )
   }
 }

--- a/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/search/components/SpotifySearchScreen.kt
+++ b/demos/spotify/src/main/java/com/guru/composecookbook/spotify/ui/search/components/SpotifySearchScreen.kt
@@ -34,7 +34,7 @@ fun SpotifySearchScreen() {
       modifier =
         Modifier.padding(top = 80.dp, bottom = 40.dp)
           .fillMaxSize()
-          .alpha(1f - scrollState.value / 200)
+          .alpha(1f - scrollState.value / 200),
       // Just reducing the opacity by small fraction when scroll happens
     )
     Column(modifier = Modifier.verticalScroll(scrollState)) {

--- a/demos/tiktok/build.gradle.kts
+++ b/demos/tiktok/build.gradle.kts
@@ -4,24 +4,20 @@ import com.guru.composecookbook.build.dependencies.addGoogleAndroidDependencies
 import com.guru.composecookbook.build.dependencies.addThirdPartyUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.tiktok"
-}
+android { namespace = "com.guru.composecookbook.tiktok" }
 
 dependencies {
-    implementation(project(":components:carousel"))
-    implementation(project(":components:verticalgrid"))
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":components:carousel"))
+  implementation(project(":components:verticalgrid"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
-    addThirdPartyUiDependencies()
-    addGoogleAndroidDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
+  addThirdPartyUiDependencies()
+  addGoogleAndroidDependencies()
 }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TikTokScreen.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TikTokScreen.kt
@@ -2,9 +2,14 @@ package com.guru.composecookbook.tiktok
 
 sealed class TikTokScreen(val route: String) {
   object Home : TikTokScreen("Home")
+
   object Discover : TikTokScreen("Discover")
+
   object Create : TikTokScreen("Create")
+
   object Inbox : TikTokScreen("Inbox")
+
   object Me : TikTokScreen("Me")
+
   object Profile : TikTokScreen("Profile")
 }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TiktokActivity.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TiktokActivity.kt
@@ -52,11 +52,8 @@ fun TiktokAppContent() {
   Scaffold(
     bottomBar = { TikTokBottomNavigation(navController) },
     content = { paddingValues ->
-      TikTokBodyContent(
-        navController = navController,
-        modifier = Modifier.padding(paddingValues),
-      )
-    }
+      TikTokBodyContent(navController = navController, modifier = Modifier.padding(paddingValues))
+    },
   )
 }
 
@@ -101,10 +98,7 @@ fun BottomBarIcon(screen: TikTokScreen) {
 }
 
 @Composable
-fun TikTokBodyContent(
-  navController: NavHostController,
-  modifier: Modifier = Modifier,
-) {
+fun TikTokBodyContent(navController: NavHostController, modifier: Modifier = Modifier) {
   NavHost(
     navController = navController,
     startDestination = TikTokScreen.Home.route,
@@ -126,7 +120,7 @@ fun TikTokBodyContent(
 
 fun handleInteractionEvent(
   tiktokHomeInteractionEvents: TiktokHomeInteractionEvents,
-  navController: NavHostController
+  navController: NavHostController,
 ) {
   when (tiktokHomeInteractionEvents) {
     is TiktokHomeInteractionEvents.OpenProfile -> {

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TiktokDemoDataProvider.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TiktokDemoDataProvider.kt
@@ -9,7 +9,7 @@ object TiktokDemoDataProvider {
       TikTokScreen.Discover,
       TikTokScreen.Create,
       TikTokScreen.Inbox,
-      TikTokScreen.Me
+      TikTokScreen.Me,
     )
 
   val lanes =

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TiktokHomeInteractionEvents.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/TiktokHomeInteractionEvents.kt
@@ -4,6 +4,8 @@ import com.guru.composecookbook.data.model.Album
 
 sealed class TiktokHomeInteractionEvents {
   data class OpenProfile(val album: Album) : TiktokHomeInteractionEvents()
+
   data class ShareVideo(val album: Album) : TiktokHomeInteractionEvents()
+
   object OpenComments : TiktokHomeInteractionEvents()
 }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/discovers/LanesSection.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/discovers/LanesSection.kt
@@ -30,7 +30,7 @@ fun LanesSection() {
   LazyColumn {
     itemsIndexed(
       items = TiktokDemoDataProvider.lanes,
-      itemContent = { _, laneItem -> LaneSection(laneItem) }
+      itemContent = { _, laneItem -> LaneSection(laneItem) },
     )
   }
 }
@@ -44,20 +44,20 @@ fun LaneSection(laneItem: String, modifier: Modifier = Modifier) {
         contentDescription = null,
         modifier =
           Modifier.size(32.dp)
-            .border(border = BorderStroke(0.5.dp, Color.LightGray), shape = CircleShape)
+            .border(border = BorderStroke(0.5.dp, Color.LightGray), shape = CircleShape),
       )
       Column(modifier = Modifier.padding(horizontal = 16.dp).weight(1f)) {
         Text(
           text = laneItem,
           modifier = Modifier.padding(vertical = 4.dp),
-          style = typography.h6.copy(fontSize = 14.sp)
+          style = typography.h6.copy(fontSize = 14.sp),
         )
         Text(text = "Trending Hashtag", style = typography.subtitle2)
       }
       Text(
         text = "${laneItem.length}.2M",
         style = typography.h6.copy(fontSize = 12.sp),
-        modifier = Modifier.background(customGray).padding(horizontal = 16.dp, vertical = 4.dp)
+        modifier = Modifier.background(customGray).padding(horizontal = 16.dp, vertical = 4.dp),
       )
     }
     LazyRow { items(items = (1..8).toList(), itemContent = { MediaItem(it) }) }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/discovers/SearchSection.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/discovers/SearchSection.kt
@@ -25,12 +25,12 @@ fun SearchSection() {
       Icon(
         imageVector = Icons.Default.Search,
         modifier = Modifier.padding(4.dp),
-        contentDescription = null
+        contentDescription = null,
       )
       Text(
         text = "Search",
         color = Color.DarkGray,
-        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
       )
     }
     IconButton(onClick = {}) {

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/home/HomeScreen.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/home/HomeScreen.kt
@@ -61,7 +61,7 @@ fun HomeScreen(tiktokInteractionEvents: (TiktokHomeInteractionEvents) -> Unit) {
   Pager(
     state = pagerState,
     orientation = Orientation.Vertical,
-    modifier = Modifier.fillMaxSize().padding(bottom = bottomBarHeight)
+    modifier = Modifier.fillMaxSize().padding(bottom = bottomBarHeight),
   ) {
     val movie = movies[commingPage]
     val isSelected = pagerState.currentPage == commingPage
@@ -73,7 +73,7 @@ fun HomeScreen(tiktokInteractionEvents: (TiktokHomeInteractionEvents) -> Unit) {
 fun PagerItem(
   album: Album,
   selected: Boolean,
-  tiktokInteractionEvents: (TiktokHomeInteractionEvents) -> Unit
+  tiktokInteractionEvents: (TiktokHomeInteractionEvents) -> Unit,
 ) {
   val context = LocalContext.current
 
@@ -94,7 +94,7 @@ fun VideoOverLayUI(album: Album, tiktokInteractionEvents: (TiktokHomeInteraction
 @Composable
 fun VideoIconsSection(
   album: Album,
-  tiktokInteractionEvents: (TiktokHomeInteractionEvents) -> Unit
+  tiktokInteractionEvents: (TiktokHomeInteractionEvents) -> Unit,
 ) {
   Column(horizontalAlignment = Alignment.CenterHorizontally) {
     ProfileImageWithFollow(
@@ -104,29 +104,29 @@ fun VideoIconsSection(
             onClick = { tiktokInteractionEvents(TiktokHomeInteractionEvents.OpenProfile(album)) }
           ),
       true,
-      album.imageId
+      album.imageId,
     )
     Spacer(modifier = Modifier.height(20.dp))
     LikeIcon(album.id)
     Text(
       text = "256.4k",
       style = MaterialTheme.typography.body2.copy(fontSize = 12.sp),
-      modifier = Modifier.padding(top = 4.dp, bottom = 20.dp)
+      modifier = Modifier.padding(top = 4.dp, bottom = 20.dp),
     )
     Icon(
       painter = painterResource(id = ThemeR.drawable.ic_comment_dots_solid),
-      contentDescription = null
+      contentDescription = null,
     )
     Text(
       text = "1223",
       style = MaterialTheme.typography.body2.copy(fontSize = 12.sp),
-      modifier = Modifier.padding(top = 4.dp, bottom = 20.dp)
+      modifier = Modifier.padding(top = 4.dp, bottom = 20.dp),
     )
     Icon(painter = painterResource(id = ThemeR.drawable.ic_share_solid), contentDescription = null)
     Text(
       text = "238",
       style = MaterialTheme.typography.body2.copy(fontSize = 12.sp),
-      modifier = Modifier.padding(top = 4.dp, bottom = 32.dp)
+      modifier = Modifier.padding(top = 4.dp, bottom = 32.dp),
     )
     val rotation = remember { Animatable(0f) }
     LaunchedEffect(Unit) {
@@ -142,7 +142,7 @@ fun VideoIconsSection(
     ProfileImageWithFollow(
       modifier = Modifier.size(64.dp).graphicsLayer(rotationZ = rotation.value),
       false,
-      album.imageId
+      album.imageId,
     )
   }
 }
@@ -153,10 +153,7 @@ fun LikeIcon(id: Int) {
   val animatedProgress = remember { Animatable(0f) }
   if (!fav) {
     LaunchedEffect(fav) {
-      animatedProgress.animateTo(
-        targetValue = 1.3f,
-        animationSpec = tween(600),
-      )
+      animatedProgress.animateTo(targetValue = 1.3f, animationSpec = tween(600))
     }
   }
   Icon(
@@ -165,7 +162,7 @@ fun LikeIcon(id: Int) {
     modifier =
       Modifier.clickable(onClick = { fav = !fav })
         .graphicsLayer(scaleX = animatedProgress.value, scaleY = animatedProgress.value),
-    tint = animateColorAsState(if (fav) tiktokRed else Color.White).value
+    tint = animateColorAsState(if (fav) tiktokRed else Color.White).value,
   )
 }
 
@@ -176,12 +173,12 @@ fun VideoInfoSection(modifier: Modifier, album: Album) {
     Text(
       text = "@${album.artist}",
       style = MaterialTheme.typography.body2.copy(fontWeight = FontWeight.ExtraBold),
-      modifier = Modifier.padding(vertical = 8.dp)
+      modifier = Modifier.padding(vertical = 8.dp),
     )
     Text(text = album.song, style = MaterialTheme.typography.body2)
     Text(
       text = "#${album.artist} #cool #tiktok #videos",
-      style = MaterialTheme.typography.body2.copy(fontWeight = FontWeight.Medium)
+      style = MaterialTheme.typography.body2.copy(fontWeight = FontWeight.Medium),
     )
   }
 }
@@ -200,7 +197,7 @@ fun FilterTag(text: String, modifier: Modifier) {
     text = text,
     color = Color.White,
     modifier = tagModifier,
-    style = typography.body2.copy(fontWeight = FontWeight.Bold)
+    style = typography.body2.copy(fontWeight = FontWeight.Bold),
   )
 }
 
@@ -213,7 +210,7 @@ fun ProfileImageWithFollow(modifier: Modifier, showFollow: Boolean, imageId: Int
         imageVector = Icons.Filled.Add,
         contentDescription = null,
         modifier =
-          Modifier.size(20.dp).clip(CircleShape).background(tiktokRed).align(Alignment.BottomCenter)
+          Modifier.size(20.dp).clip(CircleShape).background(tiktokRed).align(Alignment.BottomCenter),
       )
     }
   } else {
@@ -230,6 +227,6 @@ fun ImageWithBorder(imageId: Int, modifier: Modifier) {
       modifier
         .padding(8.dp)
         .clip(CircleShape)
-        .border(shape = CircleShape, border = BorderStroke(1.dp, color = Color.White))
+        .border(shape = CircleShape, border = BorderStroke(1.dp, color = Color.White)),
   )
 }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/home/TiktokCreateIcon.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/home/TiktokCreateIcon.kt
@@ -42,7 +42,7 @@ fun TiktokCreateIcon() {
       modifier =
         Modifier.clip(RoundedCornerShape(8.dp))
           .background(Color.White)
-          .padding(vertical = 4.dp, horizontal = 8.dp)
+          .padding(vertical = 4.dp, horizontal = 8.dp),
     )
   }
 }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/profile/ProfileAppBar.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/profile/ProfileAppBar.kt
@@ -23,7 +23,7 @@ fun ProfileAppBar(album: Album, navHostController: NavHostController) {
       IconButton(onClick = { navHostController.popBackStack() }) {
         Icon(
           imageVector = Icons.Filled.ArrowBack,
-          contentDescription = stringResource(id = R.string.cd_back)
+          contentDescription = stringResource(id = R.string.cd_back),
         )
       }
     },
@@ -31,9 +31,9 @@ fun ProfileAppBar(album: Album, navHostController: NavHostController) {
       IconButton(onClick = {}) {
         Icon(
           imageVector = Icons.Filled.MoreVert,
-          contentDescription = stringResource(id = R.string.cd_back)
+          contentDescription = stringResource(id = R.string.cd_back),
         )
       }
-    }
+    },
   )
 }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/profile/ProfileTabs.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/profile/ProfileTabs.kt
@@ -35,14 +35,14 @@ fun ProfileTabs() {
     Tab(
       selected = selectedIndex == 0,
       onClick = { selectedIndex = 0 },
-      modifier = Modifier.padding(12.dp)
+      modifier = Modifier.padding(12.dp),
     ) {
       Icon(imageVector = Icons.Default.VerticalDistribute, contentDescription = null)
     }
     Tab(
       selected = selectedIndex == 0,
       onClick = { selectedIndex = 1 },
-      modifier = Modifier.padding(12.dp)
+      modifier = Modifier.padding(12.dp),
     ) {
       Icon(imageVector = Icons.Default.FavoriteBorder, contentDescription = null)
     }
@@ -55,7 +55,7 @@ fun ProfileTabs() {
         painter = painterResource(id = it.imageId),
         contentDescription = null,
         modifier = Modifier.fillMaxWidth().height(150.dp),
-        contentScale = ContentScale.Crop
+        contentScale = ContentScale.Crop,
       )
     }
   }

--- a/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/profile/ProfileTopSection.kt
+++ b/demos/tiktok/src/main/java/com/guru/composecookbook/tiktok/components/profile/ProfileTopSection.kt
@@ -39,34 +39,34 @@ fun ProfileTopSection(album: Album) {
   Image(
     painter = painterResource(id = album.imageId),
     contentDescription = null,
-    modifier = Modifier.size(100.dp).clip(CircleShape)
+    modifier = Modifier.size(100.dp).clip(CircleShape),
   )
   Text(
     text = "@${album.artist.trim()}",
     style = MaterialTheme.typography.h6,
-    modifier = Modifier.padding(8.dp)
+    modifier = Modifier.padding(8.dp),
   )
   Row(
     modifier = Modifier.fillMaxWidth().padding(12.dp),
-    horizontalArrangement = Arrangement.Center
+    horizontalArrangement = Arrangement.Center,
   ) {
     Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = Modifier.padding(horizontal = 24.dp)
+      modifier = Modifier.padding(horizontal = 24.dp),
     ) {
       Text(text = "15", style = MaterialTheme.typography.h6)
       Text(text = "Following", style = MaterialTheme.typography.subtitle2)
     }
     Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = Modifier.padding(horizontal = 24.dp)
+      modifier = Modifier.padding(horizontal = 24.dp),
     ) {
       Text(text = "157k", style = MaterialTheme.typography.h6)
       Text(text = "Followers", style = MaterialTheme.typography.subtitle2)
     }
     Column(
       horizontalAlignment = Alignment.CenterHorizontally,
-      modifier = Modifier.padding(horizontal = 32.dp)
+      modifier = Modifier.padding(horizontal = 32.dp),
     ) {
       Text(text = "1.78M", style = MaterialTheme.typography.h6)
       Text(text = "Likes", style = MaterialTheme.typography.subtitle2)
@@ -76,7 +76,7 @@ fun ProfileTopSection(album: Album) {
     Button(
       onClick = {},
       colors = ButtonDefaults.buttonColors(backgroundColor = tiktokRed, contentColor = Color.White),
-      modifier = Modifier.height(50.dp).padding(horizontal = 2.dp)
+      modifier = Modifier.height(50.dp).padding(horizontal = 2.dp),
     ) {
       Text(text = "Follow", modifier = Modifier.padding(horizontal = 32.dp))
     }
@@ -89,8 +89,8 @@ fun ProfileTopSection(album: Album) {
           .padding(2.dp)
           .border(
             border = BorderStroke(1.dp, color = MaterialTheme.colors.onSurface),
-            shape = RoundedCornerShape(4.dp)
-          )
+            shape = RoundedCornerShape(4.dp),
+          ),
     )
     Icon(
       imageVector = Icons.Default.ArrowDropDown,
@@ -101,15 +101,15 @@ fun ProfileTopSection(album: Album) {
           .padding(2.dp)
           .border(
             border = BorderStroke(1.dp, color = MaterialTheme.colors.onSurface),
-            shape = RoundedCornerShape(4.dp)
-          )
+            shape = RoundedCornerShape(4.dp),
+          ),
     )
   }
   Text(
     text = "My Songs and albums- ${album.song}, ${album.descriptions}: Stay Tuned",
     modifier = Modifier.padding(vertical = 8.dp, horizontal = 32.dp),
     style = MaterialTheme.typography.body2,
-    textAlign = TextAlign.Center
+    textAlign = TextAlign.Center,
   )
   ProfileTabs()
 }

--- a/demos/twitter/build.gradle.kts
+++ b/demos/twitter/build.gradle.kts
@@ -2,20 +2,16 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.twitter"
-}
+android { namespace = "com.guru.composecookbook.twitter" }
 
 dependencies {
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/TwitterActivity.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/TwitterActivity.kt
@@ -23,11 +23,11 @@ class TwitterActivity : ComponentActivity() {
         val tweets = remember { DemoDataProvider.tweetList }
         TwitterHome(
           tweets = tweets,
-          onMessagesClick = { /*TODO*/},
-          onRetweetClick = { /*TODO*/},
-          onLikesClick = { /*TODO*/},
-          onShareClick = { /*TODO*/},
-          onNewTweetClicked = { /*TODO*/}
+          onMessagesClick = { /*TODO*/ },
+          onRetweetClick = { /*TODO*/ },
+          onLikesClick = { /*TODO*/ },
+          onShareClick = { /*TODO*/ },
+          onNewTweetClicked = { /*TODO*/ },
         )
       }
     }
@@ -45,11 +45,11 @@ fun DefaultPreview4() {
   ComposeCookBookMaterial3Theme {
     TwitterHome(
       tweets = DemoDataProvider.tweetList,
-      onMessagesClick = { /*TODO*/},
-      onRetweetClick = { /*TODO*/},
-      onLikesClick = { /*TODO*/},
-      onShareClick = { /*TODO*/},
-      onNewTweetClicked = { /*TODO*/}
+      onMessagesClick = { /*TODO*/ },
+      onRetweetClick = { /*TODO*/ },
+      onLikesClick = { /*TODO*/ },
+      onShareClick = { /*TODO*/ },
+      onNewTweetClicked = { /*TODO*/ },
     )
   }
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/TwitterHome.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/TwitterHome.kt
@@ -35,7 +35,7 @@ fun TwitterHome(
   onLikesClick: () -> Unit,
   onShareClick: () -> Unit,
   onNewTweetClicked: () -> Unit,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Scaffold(
     modifier = modifier,
@@ -46,7 +46,7 @@ fun TwitterHome(
             painter = painterResource(id = R.drawable.ic_twitter),
             contentDescription = null,
             tint = twitterColor,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
           )
         },
         backgroundColor = MaterialTheme.colorScheme.surface,
@@ -56,16 +56,16 @@ fun TwitterHome(
           ProfilePicture(
             profileImageId = R.drawable.p6,
             size = ProfilePictureSizes.small,
-            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp)
+            modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
           )
         },
         actions = {
           Icon(
             imageVector = Icons.Default.StarBorder,
             contentDescription = null,
-            modifier = Modifier.padding(horizontal = 8.dp)
+            modifier = Modifier.padding(horizontal = 8.dp),
           )
-        }
+        },
       )
     },
     floatingActionButton = {
@@ -75,7 +75,7 @@ fun TwitterHome(
           Icon(painter = painterResource(id = R.drawable.ic_twitter), contentDescription = null)
         },
         onClick = onNewTweetClicked,
-        containerColor = twitterColor
+        containerColor = twitterColor,
       )
     },
     content = { paddingValues ->
@@ -90,7 +90,7 @@ fun TwitterHome(
           )
         }
       }
-    }
+    },
   )
 }
 
@@ -99,10 +99,10 @@ fun TwitterHome(
 fun ShowTwitterScreen() {
   TwitterHome(
     tweets = DemoDataProvider.tweetList,
-    onMessagesClick = { /*TODO*/},
-    onRetweetClick = { /*TODO*/},
-    onLikesClick = { /*TODO*/},
-    onShareClick = { /*TODO*/},
-    onNewTweetClicked = { /*TODO*/}
+    onMessagesClick = { /*TODO*/ },
+    onRetweetClick = { /*TODO*/ },
+    onLikesClick = { /*TODO*/ },
+    onShareClick = { /*TODO*/ },
+    onNewTweetClicked = { /*TODO*/ },
   )
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/icons/IconCounter.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/icons/IconCounter.kt
@@ -48,7 +48,7 @@ object IconCounters {
       counter = counter,
       modifier =
         modifier.semantics { contentDescription = "$counter reactions. Create a reply too!" },
-      onClick = onClick
+      onClick = onClick,
     )
   }
 
@@ -59,7 +59,7 @@ object IconCounters {
       counter = counter,
       modifier =
         modifier.semantics { contentDescription = "$counter retweets. Retweet this tweet too!" },
-      onClick = onClick
+      onClick = onClick,
     )
   }
 
@@ -69,7 +69,7 @@ object IconCounters {
       painter = rememberVectorPainter(Icons.Default.FavoriteBorder),
       counter = counter,
       modifier = modifier.semantics { contentDescription = "$counter likes. Like this tweet too!" },
-      onClick = onClick
+      onClick = onClick,
     )
   }
 }
@@ -81,7 +81,7 @@ internal fun IconCounter(
   modifier: Modifier = Modifier,
   color: Color = Color.LightGray,
   textStyle: TextStyle = MaterialTheme.typography.caption,
-  onClick: () -> Unit
+  onClick: () -> Unit,
 ) {
   IconButton(modifier = modifier, onClick = onClick) {
     Row(modifier = Modifier.height(16.dp)) {
@@ -89,13 +89,13 @@ internal fun IconCounter(
         painter = painter,
         contentDescription = null,
         modifier = Modifier.fillMaxHeight().aspectRatio(1f),
-        tint = color
+        tint = color,
       )
       Text(
         text = counter.toString(),
         modifier = Modifier.padding(start = 8.dp),
         color = color,
-        style = textStyle
+        style = textStyle,
       )
     }
   }
@@ -128,7 +128,7 @@ fun AnimatedHeartButton() {
           expandedIconSize at 50
           idleIconSize at 100
         }
-      }
+      },
     ) { needLike ->
       // in both like and not like cases, heart will have same size, we just need the
       // animation here.
@@ -154,10 +154,10 @@ fun AnimatedHeartButton() {
         .clickable(
           interactionSource = remember { MutableInteractionSource() },
           indication = null,
-          onClick = { needLike = !needLike }
+          onClick = { needLike = !needLike },
         ),
     imageVector = Icons.Default.Favorite,
     contentDescription = "",
-    colorFilter = ColorFilter.tint(heartColor)
+    colorFilter = ColorFilter.tint(heartColor),
   )
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/icons/IconCounterBar.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/icons/IconCounterBar.kt
@@ -22,7 +22,7 @@ fun IconCounterBar(
   onRetweetClick: () -> Unit,
   onLikesClick: () -> Unit,
   onShareClick: () -> Unit,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Row(modifier = modifier, horizontalArrangement = Arrangement.SpaceBetween) {
     IconCounters.MessagesCounter(counter = commentCount, onClick = onMessagesClick)
@@ -33,7 +33,7 @@ fun IconCounterBar(
         imageVector = Icons.Default.Share,
         contentDescription = null,
         modifier = Modifier.size(16.dp),
-        tint = Color.LightGray
+        tint = Color.LightGray,
       )
     }
   }
@@ -46,9 +46,9 @@ fun IconCounterBarPreview() {
     commentCount = 122,
     retweetCount = 6,
     likesCount = 32,
-    onMessagesClick = { /*TODO*/},
-    onRetweetClick = { /*TODO*/},
-    onLikesClick = { /*TODO*/},
-    onShareClick = { /*TODO*/}
+    onMessagesClick = { /*TODO*/ },
+    onRetweetClick = { /*TODO*/ },
+    onLikesClick = { /*TODO*/ },
+    onShareClick = { /*TODO*/ },
   )
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/profiles/ProfileInfo.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/profiles/ProfileInfo.kt
@@ -24,11 +24,11 @@ fun ProfileInfo(
   profilePing: String,
   time: String,
   modifier: Modifier = Modifier,
-  textStyle: TextStyle = MaterialTheme.typography.subtitle1
+  textStyle: TextStyle = MaterialTheme.typography.subtitle1,
 ) {
   Row(
     modifier = modifier.semantics { contentDescription = "$profilePing post a tweet $time ago" },
-    verticalAlignment = Alignment.Bottom
+    verticalAlignment = Alignment.Bottom,
   ) {
     Text(text = profileName, style = textStyle, fontWeight = FontWeight.Bold)
     Icon(
@@ -38,12 +38,12 @@ fun ProfileInfo(
       modifier =
         Modifier.size(textStyle.fontSize.value.dp)
           .align(Alignment.CenterVertically)
-          .padding(start = 2.dp)
+          .padding(start = 2.dp),
     )
     Text(
       text = "$profilePing · $time",
       modifier = Modifier.padding(start = 8.dp),
-      style = textStyle
+      style = textStyle,
     )
   }
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/profiles/ProfilePicture.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/profiles/ProfilePicture.kt
@@ -16,13 +16,13 @@ import androidx.compose.ui.unit.dp
 fun ProfilePicture(
   @DrawableRes profileImageId: Int,
   modifier: Modifier = Modifier,
-  size: Dp = ProfilePictureSizes.small
+  size: Dp = ProfilePictureSizes.small,
 ) {
   Image(
     painter = painterResource(id = profileImageId),
     contentDescription = null,
     contentScale = ContentScale.Crop,
-    modifier = modifier.size(size).clip(CircleShape)
+    modifier = modifier.size(size).clip(CircleShape),
   )
 }
 

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/tweets/TweetImage.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/tweets/TweetImage.kt
@@ -19,7 +19,7 @@ fun TweetImage(@DrawableRes imageId: Int, modifier: Modifier = Modifier) {
       painter = painterResource(id = imageId),
       contentDescription = null,
       modifier = modifier.fillMaxWidth().height(150.dp).clip(RoundedCornerShape(4.dp)),
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
   }
 }

--- a/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/tweets/TweetItem.kt
+++ b/demos/twitter/src/main/java/com/guru/composecookbook/twitter/components/tweets/TweetItem.kt
@@ -25,7 +25,7 @@ fun TweetItem(
   onRetweetClick: () -> Unit,
   onLikesClick: () -> Unit,
   onShareClick: () -> Unit,
-  modifier: Modifier = Modifier
+  modifier: Modifier = Modifier,
 ) {
   Row(modifier = modifier.padding(8.dp)) {
     ProfilePicture(profileImageId = tweet.authorImageId, size = ProfilePictureSizes.medium)
@@ -41,7 +41,7 @@ fun TweetItem(
         onRetweetClick = onRetweetClick,
         onLikesClick = onLikesClick,
         onShareClick = onShareClick,
-        modifier = Modifier.fillMaxWidth().padding(end = 16.dp)
+        modifier = Modifier.fillMaxWidth().padding(end = 16.dp),
       )
       Divider(thickness = 0.5.dp)
     }
@@ -54,9 +54,9 @@ fun PreviewTwitterItem() {
   val tweet = DemoDataProvider.tweet
   TweetItem(
     tweet = tweet,
-    onMessagesClick = { /*TODO*/},
-    onRetweetClick = { /*TODO*/},
-    onLikesClick = { /*TODO*/},
-    onShareClick = { /*TODO*/},
+    onMessagesClick = { /*TODO*/ },
+    onRetweetClick = { /*TODO*/ },
+    onLikesClick = { /*TODO*/ },
+    onShareClick = { /*TODO*/ },
   )
 }

--- a/demos/youtube/build.gradle.kts
+++ b/demos/youtube/build.gradle.kts
@@ -2,20 +2,16 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.youtube"
-}
+android { namespace = "com.guru.composecookbook.youtube" }
 
 dependencies {
-    implementation(project(":data"))
-    implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/demos/youtube/src/main/java/com/guru/composecookbook/youtube/components/YoutubeChip.kt
+++ b/demos/youtube/src/main/java/com/guru/composecookbook/youtube/components/YoutubeChip.kt
@@ -36,19 +36,15 @@ fun YoutubeChip(selected: Boolean, text: String, modifier: Modifier = Modifier) 
           when {
             selected -> MaterialTheme.colorScheme.surface
             else -> Color.LightGray
-          }
+          },
       ),
-    modifier = modifier
+    modifier = modifier,
   ) {
     Text(
       text = text,
       textAlign = TextAlign.Center,
       style = MaterialTheme.typography.bodyMedium,
-      modifier =
-        Modifier.padding(
-          vertical = 8.dp,
-          horizontal = 12.dp,
-        )
+      modifier = Modifier.padding(vertical = 8.dp, horizontal = 12.dp),
     )
   }
 }

--- a/demos/youtube/src/main/java/com/guru/composecookbook/youtube/components/YoutubeHome.kt
+++ b/demos/youtube/src/main/java/com/guru/composecookbook/youtube/components/YoutubeHome.kt
@@ -43,37 +43,37 @@ fun YoutubeHome() {
             painter = painterResource(id = R.drawable.ic_youtube),
             contentDescription = null,
             tint = Color.Red,
-            modifier = Modifier.padding(start = 16.dp)
+            modifier = Modifier.padding(start = 16.dp),
           )
         },
         actions = {
           Icon(
             imageVector = Icons.Default.Videocam,
             contentDescription = null,
-            modifier = Modifier.padding(horizontal = 8.dp)
+            modifier = Modifier.padding(horizontal = 8.dp),
           )
           Icon(
             imageVector = Icons.Default.Search,
             contentDescription = null,
-            modifier = Modifier.padding(horizontal = 8.dp)
+            modifier = Modifier.padding(horizontal = 8.dp),
           )
           Image(
             painter = painterResource(id = R.drawable.p3),
             contentDescription = null,
             modifier =
-              Modifier.padding(vertical = 4.dp, horizontal = 8.dp).size(24.dp).clip(CircleShape)
+              Modifier.padding(vertical = 4.dp, horizontal = 8.dp).size(24.dp).clip(CircleShape),
           )
-        }
+        },
       )
     },
     content = { paddingValues ->
       Surface(
         elevation = if (MaterialTheme.colors.isLight) 0.dp else 8.dp,
-        modifier = Modifier.padding(paddingValues)
+        modifier = Modifier.padding(paddingValues),
       ) {
         YoutubeContent()
       }
-    }
+    },
   )
 }
 
@@ -94,12 +94,9 @@ fun YoutubeContent() {
           YoutubeChip(
             selected = it.id == 2,
             text = it.author,
-            modifier =
-              Modifier.padding(
-                horizontal = 4.dp,
-              )
+            modifier = Modifier.padding(horizontal = 4.dp),
           )
-        }
+        },
       )
     }
     LazyColumn { items(items = tweets, itemContent = { item -> YoutubeListItem(item) }) }

--- a/demos/youtube/src/main/java/com/guru/composecookbook/youtube/components/YoutubeListItem.kt
+++ b/demos/youtube/src/main/java/com/guru/composecookbook/youtube/components/YoutubeListItem.kt
@@ -39,12 +39,9 @@ fun YoutubeListItem(item: Tweet) {
       contentScale = ContentScale.Crop,
       modifier =
         Modifier.height(200.dp).constrainAs(image) {
-          linkTo(
-            start = parent.start,
-            end = parent.end,
-          )
+          linkTo(start = parent.start, end = parent.end)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Image(
       painter = painterResource(id = com.guru.composecookbook.data.R.drawable.p1),
@@ -54,7 +51,7 @@ fun YoutubeListItem(item: Tweet) {
           start.linkTo(parent.start, margin = 12.dp)
           top.linkTo(image.bottom, margin = 16.dp)
           end.linkTo(title.start)
-        }
+        },
     )
     Text(
       text = item.text,
@@ -67,11 +64,11 @@ fun YoutubeListItem(item: Tweet) {
             start = authorImage.end,
             startMargin = 16.dp,
             end = button.start,
-            endMargin = 16.dp
+            endMargin = 16.dp,
           )
           linkTo(top = authorImage.top, bottom = subtitle.top)
           width = Dimension.fillToConstraints
-        }
+        },
     )
     Text(
       text = "${item.author} . ${item.likesCount}k views . 6 hours ago",
@@ -82,7 +79,7 @@ fun YoutubeListItem(item: Tweet) {
             start.linkTo(title.start)
             width = Dimension.fillToConstraints
           }
-          .padding(bottom = 24.dp)
+          .padding(bottom = 24.dp),
     )
     IconButton(
       onClick = {},
@@ -90,7 +87,7 @@ fun YoutubeListItem(item: Tweet) {
         Modifier.constrainAs(button) {
           top.linkTo(image.bottom)
           end.linkTo(parent.end)
-        }
+        },
     ) {
       Icon(Icons.Default.MoreVert, tint = Color.Gray, contentDescription = null)
     }

--- a/templates/cascademenu/build.gradle.kts
+++ b/templates/cascademenu/build.gradle.kts
@@ -2,21 +2,17 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addComposeThirdPartyDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.cascademenu"
-}
+android { namespace = "com.guru.composecookbook.cascademenu" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":data"))
-    implementation(project(":components:tags"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":components:tags"))
 
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
 }

--- a/templates/cascademenu/src/main/java/com/guru/composecookbook/cascademenu/CascadeScreen.kt
+++ b/templates/cascademenu/src/main/java/com/guru/composecookbook/cascademenu/CascadeScreen.kt
@@ -50,7 +50,7 @@ fun CascadeScreen() {
   Scaffold(
     modifier = Modifier.fillMaxSize(),
     backgroundColor = Color.Transparent,
-    scaffoldState = rememberScaffoldState(snackbarHostState = snackbarHostState)
+    scaffoldState = rememberScaffoldState(snackbarHostState = snackbarHostState),
   ) { paddingValues ->
     Column(
       modifier = Modifier.padding(paddingValues).fillMaxSize(),
@@ -65,7 +65,7 @@ fun CascadeScreen() {
           itemSelected = {
             channel.trySend(it)
             setIsOpen(false)
-          }
+          },
         )
         IconButton(onClick = { setIsOpen(true) }) {
           Icon(imageVector = Icons.TwoTone.MoreVert, contentDescription = null)

--- a/templates/cascademenu/src/main/java/com/guru/composecookbook/cascademenu/cascade/CascadeMenu.kt
+++ b/templates/cascademenu/src/main/java/com/guru/composecookbook/cascademenu/cascade/CascadeMenu.kt
@@ -34,7 +34,7 @@ fun animateToNext(): ContentTransform {
 
 fun <T : Any> isNavigatingBack(
   currentMenu: CascadeMenuItem<T>,
-  nextMenu: CascadeMenuItem<T>
+  nextMenu: CascadeMenuItem<T>,
 ): Boolean {
   return currentMenu.hasParent() && nextMenu == currentMenu.parent!!
 }
@@ -54,7 +54,7 @@ fun <T : Any> CascadeMenu(
     modifier = modifier.width(MAX_WIDTH).background(colors.backgroundColor),
     expanded = isOpen,
     onDismissRequest = onDismiss,
-    offset = offset
+    offset = offset,
   ) {
     val state by remember { mutableStateOf(CascadeMenuState(menu)) }
     AnimatedContent(
@@ -65,7 +65,7 @@ fun <T : Any> CascadeMenu(
         } else {
           animateToNext()
         }
-      }
+      },
     ) { targetMenu ->
       CascadeMenuContent(
         state = state,
@@ -133,12 +133,7 @@ fun CascadeMenuItemText(
       MaterialTheme.typography.subtitle1
     }
 
-  Text(
-    modifier = modifier,
-    text = text,
-    style = style,
-    color = color,
-  )
+  Text(modifier = modifier, text = text, style = style, color = color)
 }
 
 @Composable
@@ -146,20 +141,16 @@ fun CascadeMenuItem(onClick: () -> Unit, content: @Composable RowScope.() -> Uni
   DropdownMenuItem(
     onClick = onClick,
     interactionSource = remember { MutableInteractionSource() },
-    content = content
+    content = content,
   )
 }
 
 @Composable
-fun CascadeHeaderItem(
-  title: String,
-  contentColor: Color,
-  onClick: () -> Unit,
-) {
+fun CascadeHeaderItem(title: String, contentColor: Color, onClick: () -> Unit) {
   CascadeMenuItem(onClick = { onClick() }) {
     CascadeMenuItemIcon(
       icon = Icons.Rounded.ArrowLeft,
-      tint = contentColor.copy(alpha = ContentAlpha.medium)
+      tint = contentColor.copy(alpha = ContentAlpha.medium),
     )
     Spacer(modifier = Modifier.width(4.dp))
     CascadeMenuItemText(
@@ -184,11 +175,7 @@ fun <T> CascadeParentItem(
       CascadeMenuItemIcon(icon = icon, tint = contentColor)
       Space()
     }
-    CascadeMenuItemText(
-      modifier = Modifier.weight(1f),
-      text = title,
-      color = contentColor,
-    )
+    CascadeMenuItemText(modifier = Modifier.weight(1f), text = title, color = contentColor)
     Space()
     CascadeMenuItemIcon(icon = Icons.Rounded.ArrowRight, tint = contentColor)
   }
@@ -207,10 +194,6 @@ fun <T> CascadeChildItem(
       CascadeMenuItemIcon(icon = icon, tint = contentColor)
       Space()
     }
-    CascadeMenuItemText(
-      modifier = Modifier.weight(1f),
-      text = title,
-      color = contentColor,
-    )
+    CascadeMenuItemText(modifier = Modifier.weight(1f), text = title, color = contentColor)
   }
 }

--- a/templates/cascademenu/src/main/java/com/guru/composecookbook/cascademenu/cascade/CascadeMenuColors.kt
+++ b/templates/cascademenu/src/main/java/com/guru/composecookbook/cascademenu/cascade/CascadeMenuColors.kt
@@ -4,15 +4,12 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
-data class CascadeMenuColors(
-  val backgroundColor: Color,
-  val contentColor: Color,
-)
+data class CascadeMenuColors(val backgroundColor: Color, val contentColor: Color)
 
 @Composable
 fun cascadeMenuColors(
   backgroundColor: Color = MaterialTheme.colors.surface,
-  contentColor: Color = MaterialTheme.colors.onSurface
+  contentColor: Color = MaterialTheme.colors.onSurface,
 ): CascadeMenuColors {
   return CascadeMenuColors(backgroundColor, contentColor)
 }

--- a/templates/login/build.gradle.kts
+++ b/templates/login/build.gradle.kts
@@ -2,23 +2,19 @@ import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencie
 import com.guru.composecookbook.build.dependencies.addComposeThirdPartyDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.login"
-}
+android { namespace = "com.guru.composecookbook.login" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":data"))
-    implementation(project(":animations:lottie"))
-    implementation(project(":components:tags"))
-    implementation(project(":templates:onboarding"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":animations:lottie"))
+  implementation(project(":components:tags"))
+  implementation(project(":templates:onboarding"))
 
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
 }

--- a/templates/login/src/main/java/com/guru/composecookbook/login/HorizontalDottedProgressBar.kt
+++ b/templates/login/src/main/java/com/guru/composecookbook/login/HorizontalDottedProgressBar.kt
@@ -24,21 +24,16 @@ fun HorizontalDottedProgressBar() {
       animationSpec =
         infiniteRepeatable(
           animation = tween(durationMillis = 700, easing = LinearEasing),
-          repeatMode = RepeatMode.Reverse
-        )
+          repeatMode = RepeatMode.Reverse,
+        ),
     )
 
   DrawCanvas(state = state, color = color)
 }
 
 @Composable
-fun DrawCanvas(
-  state: Float,
-  color: Color,
-) {
-  Canvas(
-    modifier = Modifier.fillMaxWidth().height(60.dp),
-  ) {
+fun DrawCanvas(state: Float, color: Color) {
+  Canvas(modifier = Modifier.fillMaxWidth().height(60.dp)) {
     val radius = (4.dp).value
     val padding = (6.dp).value
 
@@ -48,14 +43,14 @@ fun DrawCanvas(
           radius = radius * 2,
           brush = SolidColor(color),
           center =
-            Offset(x = this.center.x + radius * 2 * (i - 3) + padding * (i - 3), y = this.center.y)
+            Offset(x = this.center.x + radius * 2 * (i - 3) + padding * (i - 3), y = this.center.y),
         )
       } else {
         drawCircle(
           radius = radius,
           brush = SolidColor(color),
           center =
-            Offset(x = this.center.x + radius * 2 * (i - 3) + padding * (i - 3), y = this.center.y)
+            Offset(x = this.center.x + radius * 2 * (i - 3) + padding * (i - 3), y = this.center.y),
         )
       }
     }

--- a/templates/login/src/main/java/com/guru/composecookbook/login/LoginScreen.kt
+++ b/templates/login/src/main/java/com/guru/composecookbook/login/LoginScreen.kt
@@ -58,14 +58,14 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
         Text(
           text = "Welcome Back",
           style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.ExtraBold),
-          modifier = Modifier.padding(top = 8.dp)
+          modifier = Modifier.padding(top = 8.dp),
         )
       }
       item {
         Text(
           text = "We have missed you, Let's start by Sign In!",
           style = MaterialTheme.typography.labelMedium,
-          modifier = Modifier.padding(bottom = 12.dp)
+          modifier = Modifier.padding(bottom = 12.dp),
         )
       }
 
@@ -75,7 +75,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
           leadingIcon = {
             FaIcon(
               faIcon = FaIcons.Envelope,
-              tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+              tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
             )
           },
           maxLines = 1,
@@ -96,7 +96,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
           leadingIcon = {
             FaIcon(
               faIcon = FaIcons.Key,
-              tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
+              tint = LocalContentColor.current.copy(alpha = LocalContentAlpha.current),
             )
           },
           trailingIcon = {
@@ -113,7 +113,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
                         PasswordVisualTransformation()
                       }
                   }
-                )
+                ),
             )
           },
           colors = TextFieldDefaultsMaterial.outlinedTextFieldColors(),
@@ -143,7 +143,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
             }
           },
           modifier =
-            Modifier.fillMaxWidth().padding(vertical = 16.dp).height(50.dp).clip(CircleShape)
+            Modifier.fillMaxWidth().padding(vertical = 16.dp).height(50.dp).clip(CircleShape),
         ) {
           if (loading) {
             HorizontalDottedProgressBar()
@@ -167,7 +167,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
             modifier =
               Modifier.align(Alignment.Center)
                 .background(MaterialTheme.colorScheme.background)
-                .padding(horizontal = 16.dp)
+                .padding(horizontal = 16.dp),
           )
         }
       }
@@ -182,7 +182,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
             text = "Sign in with Facebook",
             style = MaterialTheme.typography.headlineSmall.copy(fontSize = 14.sp),
             textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
           )
         }
       }
@@ -199,7 +199,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
             text = "Sign in with Gmail",
             style = MaterialTheme.typography.headlineSmall.copy(fontSize = 14.sp),
             textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
           )
         }
       }
@@ -214,7 +214,7 @@ fun LoginScreen(onLoginSuccess: () -> Unit) {
         Text(
           text = annotatedString.toAnnotatedString(),
           modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp).clickable(onClick = {}),
-          textAlign = TextAlign.Center
+          textAlign = TextAlign.Center,
         )
       }
 

--- a/templates/onboarding/build.gradle.kts
+++ b/templates/onboarding/build.gradle.kts
@@ -1,19 +1,15 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.onboarding"
-}
+android { namespace = "com.guru.composecookbook.onboarding" }
 
 dependencies {
-    implementation(project(":components:carousel"))
-    implementation(project(":animations:lottie"))
+  implementation(project(":components:carousel"))
+  implementation(project(":animations:lottie"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/templates/onboarding/src/main/java/com/guru/composecookbook/onboarding/OnboardingPagerItem.kt
+++ b/templates/onboarding/src/main/java/com/guru/composecookbook/onboarding/OnboardingPagerItem.kt
@@ -19,24 +19,24 @@ import com.guru.composecookbook.lottie.LottieLoadingView
 fun OnboardingPagerItem(item: Onboard) {
   Column(
     modifier = Modifier.padding(horizontal = 16.dp),
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     LottieLoadingView(
       context = LocalContext.current,
       file = item.lottieFile,
-      modifier = Modifier.fillMaxWidth().height(250.dp)
+      modifier = Modifier.fillMaxWidth().height(250.dp),
     )
     Text(
       text = item.title,
       style = MaterialTheme.typography.h5.copy(fontWeight = FontWeight.ExtraBold),
       textAlign = TextAlign.Center,
-      modifier = Modifier.padding(16.dp)
+      modifier = Modifier.padding(16.dp),
     )
     Text(
       text = item.description,
       style = MaterialTheme.typography.body1,
       textAlign = TextAlign.Center,
-      modifier = Modifier.padding(horizontal = 16.dp)
+      modifier = Modifier.padding(horizontal = 16.dp),
     )
   }
 }

--- a/templates/onboarding/src/main/java/com/guru/composecookbook/onboarding/OnboardingPagerSlide.kt
+++ b/templates/onboarding/src/main/java/com/guru/composecookbook/onboarding/OnboardingPagerSlide.kt
@@ -14,6 +14,6 @@ fun OnboardingPagerSlide(selected: Boolean, color: Color, icon: ImageVector) {
     imageVector = icon,
     modifier = Modifier.padding(4.dp),
     contentDescription = null,
-    tint = if (selected) color else Color.Gray
+    tint = if (selected) color else Color.Gray,
   )
 }

--- a/templates/onboarding/src/main/java/com/guru/composecookbook/onboarding/OnboardingScreen.kt
+++ b/templates/onboarding/src/main/java/com/guru/composecookbook/onboarding/OnboardingScreen.kt
@@ -30,7 +30,7 @@ fun OnBoardingScreen(onSkip: () -> Unit) {
       Pager(
         state = pagerState,
         orientation = Orientation.Horizontal,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
       ) {
         OnboardingPagerItem(onboardingList[commingPage])
       }
@@ -40,14 +40,14 @@ fun OnBoardingScreen(onSkip: () -> Unit) {
         modifier =
           Modifier.align(Alignment.TopEnd)
             .padding(vertical = 48.dp, horizontal = 16.dp)
-            .clickable(onClick = onSkip)
+            .clickable(onClick = onSkip),
       )
       Row(modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 120.dp)) {
         onboardingList.forEachIndexed { index, _ ->
           OnboardingPagerSlide(
             selected = index == pagerState.currentPage,
             MaterialTheme.colorScheme.primary,
-            Icons.Filled.Album
+            Icons.Filled.Album,
           )
         }
       }
@@ -61,12 +61,12 @@ fun OnBoardingScreen(onSkip: () -> Unit) {
             .align(Alignment.BottomCenter)
             .padding(bottom = 32.dp)
             .height(50.dp)
-            .clip(CircleShape)
+            .clip(CircleShape),
       ) {
         Text(
           text = if (pagerState.currentPage == onboardingList.size - 1) "Let's Begin" else "Next",
           modifier = Modifier.padding(horizontal = 32.dp),
-          color = MaterialTheme.colorScheme.onPrimary
+          color = MaterialTheme.colorScheme.onPrimary,
         )
       }
     }
@@ -80,16 +80,16 @@ val onboardingList =
     Onboard(
       "Team Collaborations",
       "Our tools help your teams collaborate for the best output results",
-      "profile.json"
+      "profile.json",
     ),
     Onboard(
       "Improve Productivity",
       "Our tools are designed to improve productivity by automating all the stuff for you",
-      "working.json"
+      "working.json",
     ),
     Onboard(
       "Growth Tracking",
       "We provide dashboard and charts to track your growth easily and suggestions.",
-      "food.json"
-    )
+      "food.json",
+    ),
   )

--- a/templates/paymentcard/build.gradle.kts
+++ b/templates/paymentcard/build.gradle.kts
@@ -1,18 +1,14 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.paymentcard"
-}
+android { namespace = "com.guru.composecookbook.paymentcard" }
 
 dependencies {
-    implementation(project(":theme"))
+  implementation(project(":theme"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/templates/paymentcard/src/main/java/com/guru/composecookbook/paymentcard/AddPaymentScreen.kt
+++ b/templates/paymentcard/src/main/java/com/guru/composecookbook/paymentcard/AddPaymentScreen.kt
@@ -38,7 +38,7 @@ fun AddPaymentScreen() {
             textFieldValue = nameText,
             label = stringResource(id = R.string.card_holder_name),
             onTextChanged = { nameText = it },
-            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
           )
         }
 
@@ -49,28 +49,28 @@ fun AddPaymentScreen() {
             keyboardType = KeyboardType.Number,
             onTextChanged = { cardNumber = it },
             modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-            visualTransformation = CreditCardFilter
+            visualTransformation = CreditCardFilter,
           )
         }
 
         item {
           Row(
             modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
           ) {
             InputItem(
               textFieldValue = expiryNumber,
               label = stringResource(id = R.string.expiry_date),
               keyboardType = KeyboardType.Number,
               onTextChanged = { expiryNumber = it },
-              modifier = Modifier.weight(1f).padding(end = 8.dp)
+              modifier = Modifier.weight(1f).padding(end = 8.dp),
             )
             InputItem(
               textFieldValue = cvcNumber,
               label = stringResource(id = R.string.cvc),
               keyboardType = KeyboardType.Number,
               onTextChanged = { cvcNumber = it },
-              modifier = Modifier.weight(1f).padding(start = 8.dp)
+              modifier = Modifier.weight(1f).padding(start = 8.dp),
             )
           }
         }
@@ -79,7 +79,7 @@ fun AddPaymentScreen() {
           Button(onClick = {}, modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
             Text(
               text = stringResource(id = R.string.save),
-              modifier = Modifier.padding(horizontal = 30.dp, vertical = 8.dp)
+              modifier = Modifier.padding(horizontal = 30.dp, vertical = 8.dp),
             )
           }
         }

--- a/templates/paymentcard/src/main/java/com/guru/composecookbook/paymentcard/InputItem.kt
+++ b/templates/paymentcard/src/main/java/com/guru/composecookbook/paymentcard/InputItem.kt
@@ -23,7 +23,7 @@ fun InputItem(
   modifier: Modifier = Modifier,
   visualTransformation: VisualTransformation = VisualTransformation.None,
   textStyle: TextStyle = MaterialTheme.typography.labelMedium,
-  keyboardType: KeyboardType = KeyboardType.Text
+  keyboardType: KeyboardType = KeyboardType.Text,
 ) {
   OutlinedTextField(
     value = textFieldValue,
@@ -39,6 +39,6 @@ fun InputItem(
     },
     colors = TextFieldDefaultsMaterial.outlinedTextFieldColors(),
     modifier = modifier,
-    visualTransformation = visualTransformation
+    visualTransformation = visualTransformation,
   )
 }

--- a/templates/paymentcard/src/main/java/com/guru/composecookbook/paymentcard/PaymentCard.kt
+++ b/templates/paymentcard/src/main/java/com/guru/composecookbook/paymentcard/PaymentCard.kt
@@ -33,7 +33,7 @@ fun PaymentCard(
   nameText: TextFieldValue,
   cardNumber: TextFieldValue,
   expiryNumber: TextFieldValue,
-  cvcNumber: TextFieldValue
+  cvcNumber: TextFieldValue,
 ) {
   var backVisible by remember { mutableStateOf(false) }
   var visaType by remember { mutableStateOf(CardType.None) }
@@ -73,11 +73,11 @@ fun PaymentCard(
           .height(220.dp)
           .graphicsLayer(
             rotationY = animateFloatAsState(if (backVisible) 180f else 0f).value,
-            translationY = 0f
+            translationY = 0f,
           ),
       shape = RoundedCornerShape(25.dp),
       color = animatedColor.value,
-      elevation = 18.dp
+      elevation = 18.dp,
     ) {
       Box(modifier = Modifier.fillMaxSize()) {
         AnimatedVisibility(visible = !backVisible) {
@@ -91,7 +91,7 @@ fun PaymentCard(
                 Modifier.padding(20.dp).constrainAs(symbol) {
                   start.linkTo(parent.start)
                   top.linkTo(parent.top)
-                }
+                },
             )
 
             AnimatedVisibility(
@@ -100,7 +100,7 @@ fun PaymentCard(
                 Modifier.padding(20.dp).constrainAs(logo) {
                   end.linkTo(parent.end)
                   top.linkTo(parent.top)
-                }
+                },
             ) {
               Image(painter = painterResource(id = visaType.image), contentDescription = "symbol")
             }
@@ -116,7 +116,7 @@ fun PaymentCard(
                   .constrainAs(number) {
                     linkTo(start = parent.start, end = parent.end)
                     linkTo(top = parent.top, bottom = parent.bottom)
-                  }
+                  },
             )
 
             Text(
@@ -127,7 +127,7 @@ fun PaymentCard(
                 Modifier.padding(horizontal = 16.dp).constrainAs(cardNameLabel) {
                   start.linkTo(parent.start)
                   bottom.linkTo(cardName.top)
-                }
+                },
             )
             Text(
               text = nameText.text,
@@ -139,7 +139,7 @@ fun PaymentCard(
                   .constrainAs(cardName) {
                     start.linkTo(parent.start)
                     bottom.linkTo(parent.bottom)
-                  }
+                  },
             )
 
             Text(
@@ -150,7 +150,7 @@ fun PaymentCard(
                 Modifier.padding(horizontal = 16.dp).constrainAs(expiryLabel) {
                   end.linkTo(parent.end)
                   bottom.linkTo(expiry.top)
-                }
+                },
             )
             Text(
               text = expiryNumber.text.take(4).chunked(2).joinToString("/"),
@@ -162,7 +162,7 @@ fun PaymentCard(
                   .constrainAs(expiry) {
                     end.linkTo(parent.end)
                     bottom.linkTo(parent.bottom)
-                  }
+                  },
             )
           }
         }
@@ -185,30 +185,27 @@ fun PaymentCard(
 
     AnimatedVisibility(
       visible = backVisible,
-      modifier = Modifier.padding(end = 50.dp, bottom = 50.dp).align(Alignment.BottomEnd)
+      modifier = Modifier.padding(end = 50.dp, bottom = 50.dp).align(Alignment.BottomEnd),
     ) {
       Box(
         modifier =
           Modifier.defaultMinSize(minWidth = 60.dp)
             .clip(RoundedCornerShape(4.dp))
             .background(Color.Gray),
-        contentAlignment = Alignment.Center
+        contentAlignment = Alignment.Center,
       ) {
         Text(
           text = cvcNumber.text,
           style = MaterialTheme.typography.body1,
           color = Color.White,
-          modifier = Modifier.animateContentSize().padding(vertical = 4.dp, horizontal = 16.dp)
+          modifier = Modifier.animateContentSize().padding(vertical = 4.dp, horizontal = 16.dp),
         )
       }
     }
   }
 }
 
-enum class CardType(
-  val title: String,
-  @DrawableRes val image: Int,
-) {
+enum class CardType(val title: String, @DrawableRes val image: Int) {
   None("", R.drawable.ic_visa_logo),
   Visa("visa", R.drawable.ic_visa_logo),
 }
@@ -221,6 +218,6 @@ fun PreviewPaymentCard() {
     TextFieldValue("Elbehiry"),
     TextFieldValue("*****************"),
     TextFieldValue("0224"),
-    TextFieldValue("123")
+    TextFieldValue("123"),
   )
 }

--- a/templates/pinlock/build.gradle.kts
+++ b/templates/pinlock/build.gradle.kts
@@ -2,26 +2,21 @@ import com.guru.composecookbook.build.dependencies.addBiometricDependency
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 import com.guru.composecookbook.build.dependencies.addComposeThirdPartyDependencies
 
-
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.pinlock"
-}
+android { namespace = "com.guru.composecookbook.pinlock" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":data"))
-    implementation(project(":animations:lottie"))
-    implementation(project(":components:tags"))
-    implementation(project(":templates:onboarding"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":animations:lottie"))
+  implementation(project(":components:tags"))
+  implementation(project(":templates:onboarding"))
 
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
-    addBiometricDependency()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
+  addBiometricDependency()
 }

--- a/templates/pinlock/src/main/java/com/guru/pinlock/PinLockView.kt
+++ b/templates/pinlock/src/main/java/com/guru/pinlock/PinLockView.kt
@@ -51,7 +51,7 @@ fun PinLockView() {
 
   Column(
     modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primaryContainer),
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     Spacer(modifier = Modifier.height(100.dp))
 
@@ -61,7 +61,7 @@ fun PinLockView() {
       text = "Enter pin to unlock",
       style = typography.h6,
       modifier = Modifier.padding(16.dp),
-      color = MaterialTheme.colorScheme.onPrimary
+      color = MaterialTheme.colorScheme.onPrimary,
     )
 
     Spacer(modifier = Modifier.height(100.dp))
@@ -71,7 +71,7 @@ fun PinLockView() {
         context = context,
         file = "success.json",
         iterations = 1,
-        modifier = Modifier.size(100.dp)
+        modifier = Modifier.size(100.dp),
       )
     } else {
       // PIN ICONS
@@ -81,7 +81,7 @@ fun PinLockView() {
             imageVector = if (inputPin.size > it) Icons.Default.Circle else Icons.Outlined.Circle,
             contentDescription = it.toString(),
             modifier = Modifier.padding(8.dp),
-            tint = MaterialTheme.colorScheme.onPrimary
+            tint = MaterialTheme.colorScheme.onPrimary,
           )
         }
       }
@@ -90,7 +90,7 @@ fun PinLockView() {
     Text(
       text = error.value,
       color = MaterialTheme.colorScheme.error,
-      modifier = Modifier.padding(16.dp)
+      modifier = Modifier.padding(16.dp),
     )
 
     Spacer(modifier = Modifier.height(50.dp))
@@ -122,19 +122,19 @@ fun PinLockView() {
     Row(
       modifier = Modifier.fillMaxWidth().padding(start = 10.dp),
       horizontalArrangement = Arrangement.SpaceEvenly,
-      verticalAlignment = Alignment.CenterVertically
+      verticalAlignment = Alignment.CenterVertically,
     ) {
       FaIcon(
         faIcon = FaIcons.Fingerprint,
         size = 36.dp,
         tint = MaterialTheme.colorScheme.onPrimary,
         modifier =
-          Modifier.clickable { context.startActivity(BiometricActivity.newIntent(context)) }
+          Modifier.clickable { context.startActivity(BiometricActivity.newIntent(context)) },
       )
 
       PinKeyItem(
         onClick = { inputPin.add(0) },
-        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
       ) {
         Text(text = "0", style = typography.h6, modifier = Modifier.padding(4.dp))
       }
@@ -147,7 +147,7 @@ fun PinLockView() {
             if (inputPin.isNotEmpty()) {
               inputPin.removeLast()
             }
-          }
+          },
       )
     }
   }
@@ -163,7 +163,7 @@ fun PinKeyItem(
   backgroundColor: Color = MaterialTheme.colorScheme.onPrimary,
   contentColor: Color = contentColorFor(backgroundColor),
   elevation: Dp = 4.dp,
-  content: @Composable () -> Unit
+  content: @Composable () -> Unit,
 ) {
   Surface(
     modifier = modifier.clickable { onClick.invoke() },
@@ -176,7 +176,7 @@ fun PinKeyItem(
       ProvideTextStyle(MaterialTheme.typography.displayMedium) {
         Box(
           modifier = Modifier.defaultMinSize(minWidth = 64.dp, minHeight = 64.dp),
-          contentAlignment = Alignment.Center
+          contentAlignment = Alignment.Center,
         ) {
           content()
         }

--- a/templates/profile/build.gradle.kts
+++ b/templates/profile/build.gradle.kts
@@ -1,20 +1,16 @@
 import com.guru.composecookbook.build.dependencies.addComposeOfficialDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.profile"
-}
+android { namespace = "com.guru.composecookbook.profile" }
 
 dependencies {
-    implementation(project(":theme"))
-    implementation(project(":data"))
-    implementation(project(":components:tags"))
+  implementation(project(":theme"))
+  implementation(project(":data"))
+  implementation(project(":components:tags"))
 
-    addComposeOfficialDependencies()
+  addComposeOfficialDependencies()
 }

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/BottomScrollingContent.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/BottomScrollingContent.kt
@@ -23,7 +23,7 @@ fun BottomScrollingContent() {
       text = "About Me",
       style = typography.h6,
       color = MaterialTheme.colorScheme.primary,
-      modifier = Modifier.padding(start = 8.dp, top = 12.dp)
+      modifier = Modifier.padding(start = 8.dp, top = 12.dp),
     )
     Divider(modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp))
     Text(
@@ -37,7 +37,7 @@ fun BottomScrollingContent() {
       text = "About Project",
       style = typography.h6,
       color = MaterialTheme.colorScheme.primary,
-      modifier = Modifier.padding(start = 8.dp, top = 16.dp)
+      modifier = Modifier.padding(start = 8.dp, top = 16.dp),
     )
     Divider(modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp))
     Text(

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/InterestsSection.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/InterestsSection.kt
@@ -17,7 +17,7 @@ fun InterestsSection() {
     text = "My Interests",
     style = typography.h6,
     color = MaterialTheme.colorScheme.primary,
-    modifier = Modifier.padding(start = 8.dp, top = 16.dp)
+    modifier = Modifier.padding(start = 8.dp, top = 16.dp),
   )
   Divider(modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp))
   Row(modifier = Modifier.padding(start = 8.dp, top = 8.dp)) {

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/MoreInfoSection.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/MoreInfoSection.kt
@@ -27,7 +27,7 @@ fun MoreInfoSection() {
     text = "More Info",
     style = typography.h6,
     color = MaterialTheme.colorScheme.primary,
-    modifier = Modifier.padding(start = 8.dp, top = 16.dp)
+    modifier = Modifier.padding(start = 8.dp, top = 16.dp),
   )
   Divider(modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp))
   ListItem(
@@ -35,17 +35,17 @@ fun MoreInfoSection() {
       Icon(
         painter = painterResource(id = R.drawable.ic_github_square_brands),
         modifier = Modifier.size(24.dp),
-        contentDescription = null
+        contentDescription = null,
       )
     },
     text = {
       Text(
         text = "Compose Cookbook github",
-        style = typography.body1.copy(fontWeight = FontWeight.Bold)
+        style = typography.body1.copy(fontWeight = FontWeight.Bold),
       )
     },
     secondaryText = { Text(text = "Tap to checkout the repo for the project") },
-    modifier = Modifier.clickable(onClick = { launchSocialActivity(context, "repository") })
+    modifier = Modifier.clickable(onClick = { launchSocialActivity(context, "repository") }),
   )
   ListItem(
     icon = { Icon(imageVector = Icons.Rounded.Email, contentDescription = null) },
@@ -53,7 +53,7 @@ fun MoreInfoSection() {
       Text(text = "Contact Me", style = typography.body1.copy(fontWeight = FontWeight.Bold))
     },
     secondaryText = { Text(text = "Tap to write me about any concern or info at $email") },
-    modifier = Modifier.clickable(onClick = { launchSocialActivity(context, "repository") })
+    modifier = Modifier.clickable(onClick = { launchSocialActivity(context, "repository") }),
   )
   ListItem(
     icon = { Icon(imageVector = Icons.Rounded.Settings, contentDescription = null) },
@@ -61,6 +61,6 @@ fun MoreInfoSection() {
       Text(text = "Demo Settings", style = typography.body1.copy(fontWeight = FontWeight.Bold))
     },
     secondaryText = { Text(text = "Not included yet. coming soon..") },
-    modifier = Modifier.clickable(onClick = {})
+    modifier = Modifier.clickable(onClick = {}),
   )
 }

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/MyPhotosSection.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/MyPhotosSection.kt
@@ -21,7 +21,7 @@ fun MyPhotosSection() {
     text = "My Photography",
     style = typography.h6,
     color = MaterialTheme.colorScheme.primary,
-    modifier = Modifier.padding(start = 8.dp, top = 16.dp)
+    modifier = Modifier.padding(start = 8.dp, top = 16.dp),
   )
   Divider(modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp))
   val imageModifier =
@@ -29,48 +29,48 @@ fun MyPhotosSection() {
 
   Row(
     modifier = Modifier.padding(start = 8.dp, top = 8.dp).fillMaxWidth(),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Image(
       painter = painterResource(id = R.drawable.food2),
       contentDescription = null,
       modifier = imageModifier,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Image(
       painter = painterResource(id = R.drawable.food3),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Image(
       painter = painterResource(id = R.drawable.food6),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
   }
   Row(
     modifier = Modifier.padding(start = 8.dp, top = 8.dp).fillMaxWidth(),
-    horizontalArrangement = Arrangement.SpaceBetween
+    horizontalArrangement = Arrangement.SpaceBetween,
   ) {
     Image(
       painter = painterResource(id = R.drawable.food12),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Image(
       painter = painterResource(id = R.drawable.food13),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
     Image(
       painter = painterResource(id = R.drawable.food15),
       modifier = imageModifier,
       contentDescription = null,
-      contentScale = ContentScale.Crop
+      contentScale = ContentScale.Crop,
     )
   }
 }

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/ProfileScreen.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/ProfileScreen.kt
@@ -85,16 +85,16 @@ fun TopAppBarView(scroll: Float) {
           painter = painterResource(id = R.drawable.p1),
           contentDescription = null,
           modifier =
-            Modifier.padding(vertical = 4.dp, horizontal = 8.dp).size(32.dp).clip(CircleShape)
+            Modifier.padding(vertical = 4.dp, horizontal = 8.dp).size(32.dp).clip(CircleShape),
         )
       },
       actions = {
         Icon(
           imageVector = Icons.Default.Settings,
           contentDescription = null,
-          modifier = Modifier.padding(horizontal = 8.dp)
+          modifier = Modifier.padding(horizontal = 8.dp),
         )
-      }
+      },
     )
   }
 }

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/SocialRow.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/SocialRow.kt
@@ -20,32 +20,32 @@ fun SocialRow() {
   Material3Card(
     elevation = 8.dp,
     modifier = Modifier.padding(8.dp),
-    backgroundColor = MaterialTheme.colorScheme.surface
+    backgroundColor = MaterialTheme.colorScheme.surface,
   ) {
     val context = LocalContext.current
     Row(
       horizontalArrangement = Arrangement.SpaceAround,
-      modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 16.dp)
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 32.dp, vertical = 16.dp),
     ) {
       IconButton(onClick = { launchSocialActivity(context, "github") }) {
         Icon(
           painter = painterResource(id = R.drawable.ic_github_square_brands),
           contentDescription = null,
-          tint = MaterialTheme.colorScheme.primary
+          tint = MaterialTheme.colorScheme.primary,
         )
       }
       IconButton(onClick = { launchSocialActivity(context, "twitter") }) {
         Icon(
           painter = painterResource(id = R.drawable.ic_twitter_square_brands),
           contentDescription = null,
-          tint = MaterialTheme.colorScheme.primary
+          tint = MaterialTheme.colorScheme.primary,
         )
       }
       IconButton(onClick = { launchSocialActivity(context, "linkedin") }) {
         Icon(
           painter = painterResource(id = R.drawable.ic_linkedin_brands),
           contentDescription = null,
-          tint = MaterialTheme.colorScheme.primary
+          tint = MaterialTheme.colorScheme.primary,
         )
       }
     }

--- a/templates/profile/src/main/java/com/guru/composecookbook/profile/TopScrollingContent.kt
+++ b/templates/profile/src/main/java/com/guru/composecookbook/profile/TopScrollingContent.kt
@@ -35,7 +35,7 @@ fun TopScrollingContent(scrollState: ScrollState) {
       Text(
         text = name,
         style = materialTypography.headlineSmall.copy(fontSize = 18.sp),
-        modifier = Modifier.padding(bottom = 4.dp)
+        modifier = Modifier.padding(bottom = 4.dp),
       )
       Text(text = "Android developer", style = materialTypography.labelMedium)
     }
@@ -52,6 +52,6 @@ fun AnimatedImage(scroll: Float) {
     modifier =
       Modifier.padding(start = 16.dp)
         .size(animateDpAsState(Dp(dynamicAnimationSizeValue)).value)
-        .clip(CircleShape)
+        .clip(CircleShape),
   )
 }

--- a/theme/build.gradle.kts
+++ b/theme/build.gradle.kts
@@ -3,18 +3,14 @@ import com.guru.composecookbook.build.dependencies.addComposeThirdPartyDependenc
 import com.guru.composecookbook.build.dependencies.addCoreAndroidUiDependencies
 
 plugins {
-    /**
-     * See [common-compose-module-configs-script-plugin.gradle.kts] file
-     */
-    id("common-compose-module-configs-script-plugin")
+  /** See [common-compose-module-configs-script-plugin.gradle.kts] file */
+  id("common-compose-module-configs-script-plugin")
 }
 
-android {
-    namespace = "com.guru.composecookbook.theme"
-}
+android { namespace = "com.guru.composecookbook.theme" }
 
 dependencies {
-    addComposeOfficialDependencies()
-    addComposeThirdPartyDependencies()
-    addCoreAndroidUiDependencies()
+  addComposeOfficialDependencies()
+  addComposeThirdPartyDependencies()
+  addCoreAndroidUiDependencies()
 }

--- a/theme/src/main/java/com/guru/composecookbook/theme/MaterialTheme.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/MaterialTheme.kt
@@ -101,7 +101,7 @@ private val LightGreenColorPalette =
     onSecondary = Color.Black,
     onBackground = Color.Black,
     onSurface = Color.Black,
-    onSurfaceVariant = Color.Black
+    onSurfaceVariant = Color.Black,
   )
 
 private val LightPurpleColorPalette =

--- a/theme/src/main/java/com/guru/composecookbook/theme/Shape.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/Shape.kt
@@ -8,5 +8,5 @@ val shapes =
   Shapes(
     small = RoundedCornerShape(4.dp),
     medium = RoundedCornerShape(4.dp),
-    large = RoundedCornerShape(0.dp)
+    large = RoundedCornerShape(0.dp),
   )

--- a/theme/src/main/java/com/guru/composecookbook/theme/Theme.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/Theme.kt
@@ -76,7 +76,7 @@ private val LightGreenColorPalette =
     onPrimary = Color.White,
     onSecondary = Color.Black,
     onBackground = Color.Black,
-    onSurface = Color.Black
+    onSurface = Color.Black,
   )
 
 private val LightPurpleColorPalette =
@@ -89,7 +89,7 @@ private val LightPurpleColorPalette =
     onPrimary = Color.White,
     onSecondary = Color.Black,
     onBackground = Color.Black,
-    onSurface = Color.Black
+    onSurface = Color.Black,
   )
 
 private val LightBlueColorPalette =
@@ -102,7 +102,7 @@ private val LightBlueColorPalette =
     onPrimary = Color.White,
     onSecondary = Color.Black,
     onBackground = Color.Black,
-    onSurface = Color.Black
+    onSurface = Color.Black,
   )
 
 private val LightOrangeColorPalette =
@@ -115,7 +115,7 @@ private val LightOrangeColorPalette =
     onPrimary = Color.White,
     onSecondary = Color.Black,
     onBackground = Color.Black,
-    onSurface = Color.Black
+    onSurface = Color.Black,
   )
 
 enum class ColorPallet {
@@ -123,7 +123,7 @@ enum class ColorPallet {
   GREEN,
   ORANGE,
   BLUE,
-  WALLPAPER
+  WALLPAPER,
 }
 
 @Composable

--- a/theme/src/main/java/com/guru/composecookbook/theme/Type.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/Type.kt
@@ -16,24 +16,20 @@ val typography =
     button =
       TextStyle(fontFamily = FontFamily.Default, fontWeight = FontWeight.W500, fontSize = 14.sp),
     caption =
-      TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp,
-      ),
+      TextStyle(fontFamily = FontFamily.Default, fontWeight = FontWeight.Normal, fontSize = 12.sp),
     subtitle1 =
       TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
-        color = Color.Gray
+        color = Color.Gray,
       ),
     subtitle2 =
       TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp,
-        color = Color.Gray
+        color = Color.Gray,
       ),
   )
 
@@ -48,23 +44,19 @@ val materialTypography =
     displayMedium =
       TextStyle(fontFamily = FontFamily.Default, fontWeight = FontWeight.W500, fontSize = 14.sp),
     labelSmall =
-      TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 12.sp,
-      ),
+      TextStyle(fontFamily = FontFamily.Default, fontWeight = FontWeight.Normal, fontSize = 12.sp),
     labelLarge =
       TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
-        color = Color.Gray
+        color = Color.Gray,
       ),
     labelMedium =
       TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Normal,
         fontSize = 14.sp,
-        color = Color.Gray
+        color = Color.Gray,
       ),
   )

--- a/theme/src/main/java/com/guru/composecookbook/theme/components/Material3Card.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/components/Material3Card.kt
@@ -19,7 +19,7 @@ fun Material3Card(
   contentColor: Color = contentColorFor(backgroundColor),
   border: BorderStroke? = null,
   elevation: Dp = 1.dp,
-  content: @Composable () -> Unit
+  content: @Composable () -> Unit,
 ) {
   Surface(
     modifier = modifier,
@@ -29,6 +29,6 @@ fun Material3Card(
     tonalElevation = elevation,
     shadowElevation = elevation,
     border = border,
-    content = content
+    content = content,
   )
 }

--- a/theme/src/main/java/com/guru/composecookbook/theme/helpers/TextFieldDefaultsMaterial.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/helpers/TextFieldDefaultsMaterial.kt
@@ -37,7 +37,7 @@ object TextFieldDefaultsMaterial {
     disabledLabelColor: Color = unfocusedLabelColor.copy(ContentAlpha.disabled),
     errorLabelColor: Color = MaterialTheme.colorScheme.error,
     placeholderColor: Color = MaterialTheme.colorScheme.onSurface.copy(ContentAlpha.medium),
-    disabledPlaceholderColor: Color = placeholderColor.copy(ContentAlpha.disabled)
+    disabledPlaceholderColor: Color = placeholderColor.copy(ContentAlpha.disabled),
   ): TextFieldColors =
     androidx.compose.material.TextFieldDefaults.textFieldColors(
       textColor,
@@ -60,7 +60,7 @@ object TextFieldDefaultsMaterial {
       disabledLabelColor,
       errorLabelColor,
       placeholderColor,
-      disabledPlaceholderColor
+      disabledPlaceholderColor,
     )
 
   /**
@@ -91,7 +91,7 @@ object TextFieldDefaultsMaterial {
     disabledLabelColor: Color = unfocusedLabelColor.copy(ContentAlpha.disabled),
     errorLabelColor: Color = MaterialTheme.colorScheme.error,
     placeholderColor: Color = MaterialTheme.colorScheme.onSurface.copy(ContentAlpha.medium),
-    disabledPlaceholderColor: Color = placeholderColor.copy(ContentAlpha.disabled)
+    disabledPlaceholderColor: Color = placeholderColor.copy(ContentAlpha.disabled),
   ): TextFieldColors =
     TextFieldDefaults.outlinedTextFieldColors(
       textColor,
@@ -114,6 +114,6 @@ object TextFieldDefaultsMaterial {
       disabledLabelColor,
       errorLabelColor,
       placeholderColor,
-      disabledPlaceholderColor
+      disabledPlaceholderColor,
     )
 }

--- a/theme/src/main/java/com/guru/composecookbook/theme/modifiers/ModifierExtentions.kt
+++ b/theme/src/main/java/com/guru/composecookbook/theme/modifiers/ModifierExtentions.kt
@@ -30,13 +30,13 @@ fun Modifier.diagonalGradientTint(colors: List<Color>, blendMode: BlendMode) =
       colors = gradientColors,
       start = Offset(x = 0f, y = 0f),
       end = Offset(x = size.width, y = size.height),
-      tileMode = TileMode.Clamp
+      tileMode = TileMode.Clamp,
     )
   }
 
 fun Modifier.gradientBackground(
   colors: List<Color>,
-  brushProvider: (List<Color>, Size) -> Brush
+  brushProvider: (List<Color>, Size) -> Brush,
 ): Modifier = composed {
   var size by remember { mutableStateOf(Size.Zero) }
   val gradient = remember(colors, size) { brushProvider(colors, size) }
@@ -50,7 +50,7 @@ fun Modifier.gradientBackground(
 fun Modifier.gradientTint(
   colors: List<Color>,
   blendMode: BlendMode,
-  brushProvider: (List<Color>, Size) -> Brush
+  brushProvider: (List<Color>, Size) -> Brush,
 ) = composed {
   var size by remember { mutableStateOf(Size.Zero) }
   val gradient = remember(colors, size) { brushProvider(colors, size) }


### PR DESCRIPTION
> ### 📚 Stacked PR — 1 of 18
> _First in the stack — applies directly to `master`._ · Blocks #197
>
> **▶ [This PR's own diff (2 commits)](https://github.com/dipenpradhan/ComposeCookBook/compare/master...issue-182-upgrade-kotlin-2.1)**
>
> The diff shown below by GitHub also includes the ancestor commits, because
> every PR in this stack targets `master` (base branches can only point at
> branches that exist in this repository). Use the compare link above to review
> just this PR's real change. Merge order is documented in the stack.

## Summary

Upgrades Kotlin from 1.9.22 to **2.1.20** (K2 compiler), as proposed in #182.

- `Versions.kt` / root & `buildSrc` build scripts: `kotlin-gradle-plugin` 1.9.22 → 2.1.20
- Adopt the new **Compose Compiler Gradle plugin** (`org.jetbrains.kotlin.plugin.compose`), which ships with Kotlin 2.0+ — applied in `app` and in both convention plugins (`common-compose-…` and `common-kotlin-…`)
- Remove the now-redundant `composeCompiler` version constant, `ProjectConfigs.kotlinCompilerExtensionVersion`, and all `composeOptions { kotlinCompilerExtensionVersion = … }` blocks
- Replace the removed `-Xopt-in` compiler flag with its stable spelling `-opt-in`
- Bump KSP to `2.1.20-1.0.31` to match the Kotlin version

## Why KSP had to come first

This PR stacks on #195 (KAPT → KSP): Room 2.6.1's KAPT path uses a `kotlinx-metadata-jvm` that only reads metadata up to 2.0.0 and fails against Kotlin 2.1-compiled classes (`Provided Metadata instance has version 2.1.0…`). Room's KSP processor has no such limitation.

Closes #182

## Verification

- `./gradlew assembleDebug testDebugUnitTest` passes locally (JDK 17, SDK 34)
- CI `./gradlew build` on this PR

cc @Gurupreet for review
