### PR TITLE
ci: harden workflows — least-privilege tokens, SHA-pinned release action, wrapper validation

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
     
   workflow_dispatch:
 
+permissions:
+  contents: read
 
 jobs:
 

--- a/.github/workflows/master-apk-create.yml
+++ b/.github/workflows/master-apk-create.yml
@@ -1,59 +1,40 @@
 name: Create APK from Main
 
 on:
-
   push:
-
     branches:
+      - master
 
-    - master
+# The release job updates the rolling "latest-master" prerelease.
+permissions:
+  contents: write
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
 
-    - uses: actions/checkout@v4
+      - name: set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
 
-    - name: set up JDK 17
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
-      uses: actions/setup-java@v4
+      - name: Build APK ⚙️🛠
+        run: bash ./gradlew assembleDebug
 
-      with:
-
-        java-version: '17'
-
-        distribution: 'temurin'
-
-        cache: gradle
-
-    - name: Grant execute permission for gradlew
-
-      run: chmod +x gradlew
-
-      
-
-    - name: Build APK ⚙️🛠
-
-      run: bash ./gradlew assembleDebug
-
- 
-
-    - uses: "marvinpinto/action-automatic-releases@latest"
-
-      with:
-
-          repo_token: "${{ github.token }}"
-
-          automatic_release_tag: "latest-master"
-
+      # Pinned to a commit SHA: third-party action with access to GITHUB_TOKEN.
+      # (Replaces the archived marvinpinto/action-automatic-releases@latest.)
+      - name: Update latest-master prerelease
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          tag_name: latest-master
+          name: 'Staging Build'
           prerelease: true
-
-          title: "Staging Build"
-
           files: app/build/outputs/apk/debug/app-debug.apk
-
-      

--- a/.github/workflows/wrapper-validation.yml
+++ b/.github/workflows/wrapper-validation.yml
@@ -1,0 +1,22 @@
+name: Validate Gradle Wrapper
+
+# Verifies the checksums of all checked-in gradle-wrapper.jar files against
+# the official Gradle distribution checksums — a tampered wrapper JAR cannot
+# be spotted in code review.
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Pinned to a commit SHA (third-party action).
+      - uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0


### PR DESCRIPTION
> ### 🔒 Independent PR
> Not part of the modernization stack. Touches only `.github/` — no dependency
> on any other open PR, mergeable in any order, at any time.

## Summary

Item 1 (+5) of #215 — workflow hardening with zero new infrastructure:

- **Replace `marvinpinto/action-automatic-releases@latest`** in `master-apk-create.yml`: that action is archived/unmaintained, referenced by a *mutable* tag, and receives `GITHUB_TOKEN`. Now `softprops/action-gh-release`, **pinned to a commit SHA** (`b430933…` = v3.0.0), updating the same rolling `latest-master` prerelease.
- **Least-privilege `permissions:` blocks** on `android.yml`, `build.yml` (`contents: read`) and `master-apk-create.yml` (`contents: write` for the release). Previously these inherited the default token permissions. The issue-creation workflows already had scoped permissions.
- **New `wrapper-validation.yml`**: `gradle/actions/wrapper-validation` (SHA-pinned, v6.1.0) verifies every checked-in `gradle-wrapper.jar` against official Gradle checksums on pushes and PRs — a tampered wrapper JAR is invisible in code review.

## Verification

Tested end-to-end on the fork (`dipenpradhan/ComposeCookBook`): the hardened workflows ran on a push to its master — including the release step, which successfully created/updated the `latest-master` prerelease with the APK via the new pinned action.

Refs #215

cc @Gurupreet for review
