### PR TITLE
ci: add Dependabot for gradle and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot: security updates + routine version bumps.
+# The gradle ecosystem watches build files and (once the project migrates)
+# gradle/libs.versions.toml; the github-actions ecosystem watches workflows.
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Compose artifacts must move together with the BOM
+      compose:
+        patterns:
+          - "androidx.compose*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Dependabot: security updates + routine version bumps.
+# The gradle ecosystem uses `directories` (glob) so every module's build file
+# is watched — root, buildSrc, each app/data/theme/component/template/demo subproject.
+# The github-actions ecosystem watches workflows; directories key does not apply there.
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directories:
+      - "/"
+      - "/**"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Compose artifacts must move together with the BOM
+      compose:
+        patterns:
+          - "androidx.compose*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
> ### 🔒 Independent PR
> Not part of the modernization stack. Touches only `.github/` — no dependency
> on any other open PR, mergeable in any order, at any time.

## Summary

Item 2 of #215 — `.github/dependabot.yml` enabling:

- **Gradle ecosystem**, weekly: security updates + version bumps. Compose artifacts are grouped so they always move together with the BOM. Coverage becomes complete once the version-catalog migration (#214 / issue #189) lands — Dependabot reads `gradle/libs.versions.toml` natively.
- **GitHub Actions ecosystem**, weekly: keeps workflow actions (and their SHA pins, once #216-style pinning is merged) up to date.

Both capped at 5 open PRs to avoid noise.

Refs #215

cc @Gurupreet for review
