### PR TITLE
ci: add CodeQL scanning and PR dependency review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # Weekly scan so new CodeQL queries run even without pushes
+    - cron: '26 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      # Kotlin extraction requires a real compilation; assembleDebug is the
+      # cheapest target that compiles every module.
+      - name: Build for analysis
+        run: |
+          chmod +x gradlew
+          touch local.properties
+          echo "apiKey=\"\"" >> local.properties
+          ./gradlew assembleDebug
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:java-kotlin'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency review
+
+# Flags PRs that introduce dependencies with known vulnerabilities.
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
> ### 🔒 Independent PR
> Not part of the modernization stack. Touches only `.github/` — no dependency
> on any other open PR, mergeable in any order, at any time.

## Summary

Item 3 of #215 — static analysis and PR-time dependency checks:

- **`codeql.yml`**: CodeQL scanning for `java-kotlin` on pushes/PRs to master plus a weekly cron (new queries keep running without pushes). Uses **manual build mode** (`assembleDebug` after the same `local.properties` setup as `build.yml`) because Kotlin extraction requires real compilation. Results land in the repo's Security → Code scanning tab.
- **`dependency-review.yml`**: `actions/dependency-review-action` fails PRs that introduce dependencies with high-severity known CVEs.

Both workflows run with least-privilege permissions (`security-events: write` only on the CodeQL job).

## Verification

CodeQL was exercised end-to-end on the fork (`dipenpradhan/ComposeCookBook`) via a push to its master — extraction, Gradle build and analysis complete. (SARIF upload requires code scanning to be enabled on the target repo; it is available for free on this public repo.)

Refs #215

cc @Gurupreet for review
